### PR TITLE
Add new API for map control.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.android.application).apply(false)
     alias(libs.plugins.buildKonfig).apply(false)
     alias(libs.plugins.publish).apply(false)
+    alias(libs.plugins.atomicfu).apply(false)
 }
 
 subprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,8 +14,11 @@ compose-plugin = "1.6.11"
 androidx-activity = "1.9.0"
 moko-resources = "0.24.1"
 lifecycle = "2.8.0"
+datetime = "0.6.0"
 
 publish = "0.29.0"
+
+atomicfu = "0.25.0"
 
 [libraries]
 yandex-mapkit = { module = "com.yandex.android:maps.mobile", version.ref = "yandex-mapkit" }
@@ -23,6 +26,8 @@ androidx-activity-compose = { module = "androidx.activity:activity-compose", ver
 moko-resources = { module = "dev.icerock.moko:resources", version.ref = "moko-resources" }
 moko-resources-compose = { module = "dev.icerock.moko:resources-compose", version.ref = "moko-resources" }
 lifecycle-common = { module = "org.jetbrains.androidx.lifecycle:lifecycle-common", version.ref = "lifecycle" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "datetime" }
+atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
 
 [plugins]
 buildKonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildKonfig" }
@@ -34,3 +39,4 @@ compose-plugin = { id = "org.jetbrains.compose", version.ref = "compose-plugin" 
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 cocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
 publish = { id = "com.vanniktech.maven.publish", version.ref = "publish" }
+atomicfu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "atomicfu" }

--- a/yandex-mapkit-kmp-compose/build.gradle.kts
+++ b/yandex-mapkit-kmp-compose/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.cocoapods)
     alias(libs.plugins.publish)
+    alias(libs.plugins.atomicfu)
 }
 
 val supportIosTarget = project.property("skipIosTarget") != "true"

--- a/yandex-mapkit-kmp/build.gradle.kts
+++ b/yandex-mapkit-kmp/build.gradle.kts
@@ -56,6 +56,7 @@ kotlin {
             api(libs.yandex.mapkit)
         }
         commonMain.dependencies {
+            api(libs.kotlinx.datetime)
         }
 
         commonTest.dependencies {

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/MapKit.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/MapKit.android.kt
@@ -2,35 +2,16 @@ package ru.sulgik.mapkit
 
 import android.content.Context
 import com.yandex.mapkit.MapKitFactory
+import ru.sulgik.mapkit.location.LocationManager
+import ru.sulgik.mapkit.location.toCommon
+import ru.sulgik.runtime.sensors.LocationActivityType
+import ru.sulgik.runtime.sensors.toNative
 import com.yandex.mapkit.MapKit as NativeMapKit
 
-actual class MapKit internal constructor (private val nativeMapKit: NativeMapKit) {
+actual class MapKit internal constructor(private val nativeMapKit: NativeMapKit) {
 
     fun toNative(): NativeMapKit {
         return nativeMapKit
-    }
-
-    actual companion object {
-
-        fun initialize(context: Context) {
-            MapKitFactory.initialize(context)
-        }
-
-        actual fun setApiKey(apiKey: String) {
-            MapKitFactory.setApiKey(apiKey)
-        }
-
-        actual fun getInstance(): MapKit {
-            return MapKitFactory.getInstance().toCommon()
-        }
-
-        actual fun setLocale(locale: String?) {
-            MapKitFactory.setLocale(locale)
-        }
-
-        actual fun setUserId(userId: String) {
-            MapKitFactory.setUserId(userId)
-        }
     }
 
     /**
@@ -60,6 +41,49 @@ actual class MapKit internal constructor (private val nativeMapKit: NativeMapKit
         nativeMapKit.onStop()
     }
 
+    /**
+     * Sets single global location manager that is used by every module in MapKit by default.
+     */
+    actual fun setLocationManager(locationManager: LocationManager) {
+        nativeMapKit.setLocationManager(locationManager.toNative())
+    }
+
+    /**
+     * Creates a manager that allows to listen for device location updates.
+     */
+    actual fun createLocationManager(): LocationManager {
+        return nativeMapKit.createLocationManager().toCommon()
+    }
+
+    /**
+     * Creates a manager that allows to listen for device location updates, uses activityType as a hint.
+     */
+    actual fun createLocationManager(activityType: LocationActivityType): LocationManager {
+        return nativeMapKit.createLocationManager(activityType.toNative()).toCommon()
+    }
+
+    actual companion object {
+
+        fun initialize(context: Context) {
+            MapKitFactory.initialize(context)
+        }
+
+        actual fun setApiKey(apiKey: String) {
+            MapKitFactory.setApiKey(apiKey)
+        }
+
+        actual fun getInstance(): MapKit {
+            return MapKitFactory.getInstance().toCommon()
+        }
+
+        actual fun setLocale(locale: String?) {
+            MapKitFactory.setLocale(locale)
+        }
+
+        actual fun setUserId(userId: String) {
+            MapKitFactory.setUserId(userId)
+        }
+    }
 }
 
 fun NativeMapKit.toCommon(): MapKit {

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/MapKit.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/MapKit.android.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import com.yandex.mapkit.MapKitFactory
 import ru.sulgik.mapkit.location.LocationManager
 import ru.sulgik.mapkit.location.toCommon
+import ru.sulgik.mapkit.map.MapWindow
+import ru.sulgik.mapkit.user_location.UserLocationLayer
+import ru.sulgik.mapkit.user_location.toCommon
 import ru.sulgik.runtime.sensors.LocationActivityType
 import ru.sulgik.runtime.sensors.toNative
 import com.yandex.mapkit.MapKit as NativeMapKit
@@ -60,6 +63,13 @@ actual class MapKit internal constructor(private val nativeMapKit: NativeMapKit)
      */
     actual fun createLocationManager(activityType: LocationActivityType): LocationManager {
         return nativeMapKit.createLocationManager(activityType.toNative()).toCommon()
+    }
+
+    /**
+     * Create layer with the user location icon.
+     */
+    actual fun createUserLocationLayer(mapWindow: MapWindow): UserLocationLayer {
+        return nativeMapKit.createUserLocationLayer(mapWindow.toNative()).toCommon()
     }
 
     actual companion object {

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/geometry/Cluster.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/geometry/Cluster.android.kt
@@ -21,11 +21,11 @@ actual class Cluster internal constructor(private val nativeCluster: NativeClust
         get() = nativeCluster.appearance.toCommon()
 
     actual fun addClusterTapListener(listener: ClusterTapListener) {
-        nativeCluster.addClusterTapListener(listener)
+        nativeCluster.addClusterTapListener(listener.toNative())
     }
 
     actual fun removeClusterTapListener(listener: ClusterTapListener) {
-        nativeCluster.removeClusterTapListener(listener)
+        nativeCluster.removeClusterTapListener(listener.toNative())
     }
 
 }

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/layers/ObjectEvent.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/layers/ObjectEvent.android.kt
@@ -1,0 +1,23 @@
+package ru.sulgik.mapkit.layers
+
+import ru.sulgik.mapkit.user_location.toCommon
+import com.yandex.mapkit.layers.ObjectEvent as NativeObjectEvent
+import com.yandex.mapkit.user_location.UserLocationAnchorChanged as NativeUserLocationAnchorChanged
+import com.yandex.mapkit.user_location.UserLocationIconChanged as NativeUserLocationIconChanged
+
+actual open class ObjectEvent(private val nativeObjectEvent: NativeObjectEvent) {
+
+    open fun toNative(): NativeObjectEvent {
+        return nativeObjectEvent
+    }
+
+}
+
+fun NativeObjectEvent.toCommon(): ObjectEvent {
+    return when (this) {
+        is NativeUserLocationAnchorChanged -> toCommon()
+        is NativeUserLocationIconChanged -> toCommon()
+        else -> ObjectEvent(this)
+    }
+}
+

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/location/FilteringMode.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/location/FilteringMode.android.kt
@@ -1,0 +1,17 @@
+package ru.sulgik.mapkit.location
+
+import com.yandex.mapkit.location.FilteringMode as NativeFilteringMode
+
+fun FilteringMode.toNative(): NativeFilteringMode {
+    return when (this) {
+        FilteringMode.ON -> NativeFilteringMode.ON
+        FilteringMode.OFF -> NativeFilteringMode.OFF
+    }
+}
+
+fun NativeFilteringMode.toCommon(): FilteringMode {
+    return when (this) {
+        NativeFilteringMode.ON -> FilteringMode.ON
+        NativeFilteringMode.OFF -> FilteringMode.OFF
+    }
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/location/Location.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/location/Location.android.kt
@@ -1,0 +1,32 @@
+package ru.sulgik.mapkit.location
+
+import kotlinx.datetime.Instant
+import ru.sulgik.mapkit.geometry.toCommon
+import ru.sulgik.mapkit.geometry.toNative
+import com.yandex.mapkit.location.Location as NativeLocation
+
+fun Location.toNative(): NativeLocation {
+    return NativeLocation(
+        position.toNative(),
+        accuracy,
+        altitude,
+        altitudeAccuracy,
+        heading,
+        speed,
+        absoluteTimestamp.toEpochMilliseconds(),
+        relativeTimestamp.toEpochMilliseconds(),
+    )
+}
+
+fun NativeLocation.toCommon(): Location {
+    return Location(
+        position = position.toCommon(),
+        accuracy = accuracy,
+        altitude = altitude,
+        altitudeAccuracy = altitudeAccuracy,
+        heading = heading,
+        speed = speed,
+        absoluteTimestamp = Instant.fromEpochMilliseconds(absoluteTimestamp),
+        relativeTimestamp = Instant.fromEpochMilliseconds(relativeTimestamp),
+    )
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/location/LocationListener.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/location/LocationListener.android.kt
@@ -4,17 +4,22 @@ import com.yandex.mapkit.location.Location as NativeLocation
 import com.yandex.mapkit.location.LocationListener as NativeLocationListener
 import com.yandex.mapkit.location.LocationStatus as NativeLocationStatus
 
-actual class LocationListener actual constructor(
-    private val onLocationUpdated: (location: Location) -> Unit,
-    private val onLocationStatusUpdated: (locationStatus: LocationStatus) -> Unit,
-) : NativeLocationListener {
+actual abstract class LocationListener actual constructor() {
 
-    override fun onLocationUpdated(p0: NativeLocation) {
-        onLocationUpdated.invoke(p0.toCommon())
+    private val nativeListener = object : NativeLocationListener {
+        override fun onLocationUpdated(p0: NativeLocation) {
+            onLocationUpdated(p0.toCommon())
+        }
+
+        override fun onLocationStatusUpdated(p0: NativeLocationStatus) {
+            onLocationStatusUpdated(p0.toCommon())
+        }
     }
 
-    override fun onLocationStatusUpdated(p0: NativeLocationStatus) {
-        onLocationStatusUpdated.invoke(p0.toCommon())
+    fun toNative(): NativeLocationListener {
+        return nativeListener
     }
 
+    actual abstract fun onLocationUpdated(location: Location)
+    actual abstract fun onLocationStatusUpdated(locationStatus: LocationStatus)
 }

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/location/LocationListener.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/location/LocationListener.android.kt
@@ -1,0 +1,20 @@
+package ru.sulgik.mapkit.location
+
+import com.yandex.mapkit.location.Location as NativeLocation
+import com.yandex.mapkit.location.LocationListener as NativeLocationListener
+import com.yandex.mapkit.location.LocationStatus as NativeLocationStatus
+
+actual class LocationListener actual constructor(
+    private val onLocationUpdated: (location: Location) -> Unit,
+    private val onLocationStatusUpdated: (locationStatus: LocationStatus) -> Unit,
+) : NativeLocationListener {
+
+    override fun onLocationUpdated(p0: NativeLocation) {
+        onLocationUpdated.invoke(p0.toCommon())
+    }
+
+    override fun onLocationStatusUpdated(p0: NativeLocationStatus) {
+        onLocationStatusUpdated.invoke(p0.toCommon())
+    }
+
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/location/LocationManager.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/location/LocationManager.android.kt
@@ -23,7 +23,7 @@ actual class LocationManager(private val nativeLocationManager: NativeLocationMa
             minDistance,
             allowUseInBackground,
             filteringMode.toNative(),
-            locationListener
+            locationListener.toNative()
         )
     }
 
@@ -36,11 +36,11 @@ actual class LocationManager(private val nativeLocationManager: NativeLocationMa
     }
 
     actual fun requestSingleUpdate(locationListener: LocationListener) {
-        nativeLocationManager.requestSingleUpdate(locationListener)
+        nativeLocationManager.requestSingleUpdate(locationListener.toNative())
     }
 
     actual fun unsubscribe(locationListener: LocationListener) {
-        nativeLocationManager.unsubscribe(locationListener)
+        nativeLocationManager.unsubscribe(locationListener.toNative())
     }
 
 }

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/location/LocationManager.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/location/LocationManager.android.kt
@@ -1,0 +1,50 @@
+package ru.sulgik.mapkit.location
+
+import kotlin.time.Duration
+import com.yandex.mapkit.location.LocationManager as NativeLocationManager
+
+actual class LocationManager(private val nativeLocationManager: NativeLocationManager) {
+
+    fun toNative(): NativeLocationManager {
+        return nativeLocationManager
+    }
+
+    actual fun subscribeForLocationUpdates(
+        desiredAccuracy: Double,
+        minTime: Duration,
+        minDistance: Double,
+        allowUseInBackground: Boolean,
+        filteringMode: FilteringMode,
+        locationListener: LocationListener,
+    ) {
+        nativeLocationManager.subscribeForLocationUpdates(
+            desiredAccuracy,
+            minTime.inWholeMilliseconds,
+            minDistance,
+            allowUseInBackground,
+            filteringMode.toNative(),
+            locationListener
+        )
+    }
+
+    actual fun suspend() {
+        nativeLocationManager.suspend()
+    }
+
+    actual fun resume() {
+        nativeLocationManager.resume()
+    }
+
+    actual fun requestSingleUpdate(locationListener: LocationListener) {
+        nativeLocationManager.requestSingleUpdate(locationListener)
+    }
+
+    actual fun unsubscribe(locationListener: LocationListener) {
+        nativeLocationManager.unsubscribe(locationListener)
+    }
+
+}
+
+fun NativeLocationManager.toCommon(): LocationManager {
+    return LocationManager(this)
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/location/LocationStatus.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/location/LocationStatus.android.kt
@@ -1,0 +1,19 @@
+package ru.sulgik.mapkit.location
+
+import com.yandex.mapkit.location.LocationStatus as NativeLocationStatus
+
+fun LocationStatus.toNative(): NativeLocationStatus {
+    return when (this) {
+        LocationStatus.NOT_AVAILABLE -> NativeLocationStatus.NOT_AVAILABLE
+        LocationStatus.AVAILABLE -> NativeLocationStatus.AVAILABLE
+        LocationStatus.RESET -> NativeLocationStatus.RESET
+    }
+}
+
+fun NativeLocationStatus.toCommon(): LocationStatus {
+    return when (this) {
+        NativeLocationStatus.NOT_AVAILABLE -> LocationStatus.NOT_AVAILABLE
+        NativeLocationStatus.AVAILABLE -> LocationStatus.AVAILABLE
+        NativeLocationStatus.RESET -> LocationStatus.RESET
+    }
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/location/LocationViewSource.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/location/LocationViewSource.android.kt
@@ -1,0 +1,20 @@
+package ru.sulgik.mapkit.location
+
+import com.yandex.mapkit.location.LocationViewSource as NativeLocationViewSource
+import com.yandex.mapkit.location.LocationViewSourceFactory as NativeLocationViewSourceFactory
+
+actual class LocationViewSource(private val nativeLocationViewSource: NativeLocationViewSource) {
+
+    fun toNative(): NativeLocationViewSource {
+        return nativeLocationViewSource
+    }
+
+}
+
+fun NativeLocationViewSource.toCommon(): LocationViewSource {
+    return LocationViewSource(this)
+}
+
+actual fun LocationManager.toLocationViewSource(): LocationViewSource {
+    return NativeLocationViewSourceFactory.createLocationViewSource(this.toNative()).toCommon()
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/logo/Alignment.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/logo/Alignment.android.kt
@@ -1,0 +1,14 @@
+package ru.sulgik.mapkit.logo
+
+import com.yandex.mapkit.logo.Alignment as NativeAlignment
+
+fun Alignment.toNative() : NativeAlignment {
+    return NativeAlignment(horizontalAlignment.toNative(), verticalAlignment.toNative())
+}
+
+fun NativeAlignment.toCommon(): Alignment {
+    return Alignment(
+        horizontalAlignment = horizontalAlignment.toCommon(),
+        verticalAlignment = verticalAlignment.toCommon(),
+    )
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/logo/HorizontalAlignment.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/logo/HorizontalAlignment.android.kt
@@ -1,0 +1,19 @@
+package ru.sulgik.mapkit.logo
+
+import com.yandex.mapkit.logo.HorizontalAlignment as NativeHorizontalAlignment
+
+fun HorizontalAlignment.toNative(): NativeHorizontalAlignment {
+    return when (this) {
+        HorizontalAlignment.LEFT -> NativeHorizontalAlignment.LEFT
+        HorizontalAlignment.CENTER -> NativeHorizontalAlignment.CENTER
+        HorizontalAlignment.RIGHT -> NativeHorizontalAlignment.RIGHT
+    }
+}
+
+fun NativeHorizontalAlignment.toCommon(): HorizontalAlignment {
+    return when (this) {
+        NativeHorizontalAlignment.LEFT -> HorizontalAlignment.LEFT
+        NativeHorizontalAlignment.CENTER -> HorizontalAlignment.CENTER
+        NativeHorizontalAlignment.RIGHT -> HorizontalAlignment.RIGHT
+    }
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/logo/Logo.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/logo/Logo.android.kt
@@ -1,0 +1,23 @@
+package ru.sulgik.mapkit.logo
+
+import com.yandex.mapkit.logo.Logo as NativeLogo
+
+actual class Logo internal constructor(private val nativeLogo: NativeLogo) {
+
+    fun toNative(): NativeLogo {
+        return nativeLogo
+    }
+
+    actual fun setAlignment(alignment: Alignment) {
+        nativeLogo.setAlignment(alignment.toNative())
+    }
+
+    actual fun setPadding(padding: Padding) {
+        nativeLogo.setPadding(padding.toNative())
+    }
+
+}
+
+fun NativeLogo.toCommon(): Logo {
+    return Logo(this)
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/logo/Padding.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/logo/Padding.android.kt
@@ -1,0 +1,14 @@
+package ru.sulgik.mapkit.logo
+
+import com.yandex.mapkit.logo.Padding as NativePadding
+
+fun Padding.toNative(): NativePadding {
+    return NativePadding(horizontalPadding, verticalPadding)
+}
+
+fun NativePadding.toCommon(): Padding {
+    return Padding(
+        horizontalPadding = horizontalPadding,
+        verticalPadding = verticalPadding
+    )
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/logo/VerticalAlignment.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/logo/VerticalAlignment.android.kt
@@ -1,0 +1,18 @@
+package ru.sulgik.mapkit.logo
+
+import com.yandex.mapkit.logo.VerticalAlignment as NativeVerticalAlignment
+
+
+fun VerticalAlignment.toNative(): NativeVerticalAlignment {
+    return when (this) {
+        VerticalAlignment.TOP -> NativeVerticalAlignment.TOP
+        VerticalAlignment.BOTTOM -> NativeVerticalAlignment.BOTTOM
+    }
+}
+
+fun NativeVerticalAlignment.toCommon(): VerticalAlignment {
+    return when (this) {
+        NativeVerticalAlignment.TOP -> VerticalAlignment.TOP
+        NativeVerticalAlignment.BOTTOM -> VerticalAlignment.BOTTOM
+    }
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/BaseMapObjectCollection.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/BaseMapObjectCollection.android.kt
@@ -25,11 +25,11 @@ actual open class BaseMapObjectCollection internal constructor(
     }
 
     actual fun addListener(collectionListener: MapObjectCollectionListener) {
-        nativeBaseMapObjectCollection.addListener(collectionListener)
+        nativeBaseMapObjectCollection.addListener(collectionListener.toNative())
     }
 
     actual fun removeListener(collectionListener: MapObjectCollectionListener) {
-        nativeBaseMapObjectCollection.removeListener(collectionListener)
+        nativeBaseMapObjectCollection.removeListener(collectionListener.toNative())
     }
 
 }

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/BaseMapObjectCollection.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/BaseMapObjectCollection.android.kt
@@ -1,11 +1,12 @@
 package ru.sulgik.mapkit.map
 
 import com.yandex.mapkit.map.BaseMapObjectCollection as NativeBaseMapObjectCollection
+import com.yandex.mapkit.map.ClusterizedPlacemarkCollection as NativeClusterizedPlacemarkCollection1
+import com.yandex.mapkit.map.MapObjectCollection as NativeMapObjectCollection
 
 actual open class BaseMapObjectCollection internal constructor(
     private val nativeBaseMapObjectCollection: NativeBaseMapObjectCollection,
-) :
-    MapObject(nativeBaseMapObjectCollection) {
+) : MapObject(nativeBaseMapObjectCollection) {
 
     override fun toNative(): NativeBaseMapObjectCollection {
         return nativeBaseMapObjectCollection
@@ -31,4 +32,12 @@ actual open class BaseMapObjectCollection internal constructor(
         nativeBaseMapObjectCollection.removeListener(collectionListener)
     }
 
+}
+
+fun NativeBaseMapObjectCollection.toCommon(): BaseMapObjectCollection {
+    return when (this) {
+        is NativeMapObjectCollection -> toCommon()
+        is NativeClusterizedPlacemarkCollection1 -> toCommon()
+        else -> BaseMapObjectCollection(this)
+    }
 }

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/Callback.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/Callback.android.kt
@@ -2,4 +2,13 @@ package ru.sulgik.mapkit.map
 
 import com.yandex.mapkit.map.Callback as NativeCallback
 
-actual abstract class Callback actual constructor(): NativeCallback
+actual abstract class Callback actual constructor() {
+
+    private val nativeCallback = NativeCallback { onTaskFinished() }
+
+    fun toNative(): NativeCallback {
+        return nativeCallback
+    }
+
+    actual abstract fun onTaskFinished()
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/CameraCallback.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/CameraCallback.android.kt
@@ -2,4 +2,14 @@ package ru.sulgik.mapkit.map
 
 import com.yandex.mapkit.map.Map.CameraCallback as NativeCameraCallback
 
-actual abstract class CameraCallback: NativeCameraCallback
+actual abstract class CameraCallback {
+
+    private val nativeCallback = NativeCameraCallback { onMoveFinished(it) }
+
+    fun toNative(): NativeCameraCallback {
+        return nativeCallback
+    }
+
+    actual abstract fun onMoveFinished(completed: Boolean)
+
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/CameraListener.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/CameraListener.android.kt
@@ -1,26 +1,28 @@
 package ru.sulgik.mapkit.map
 
+import com.yandex.mapkit.map.CameraListener
 import com.yandex.mapkit.map.CameraListener as NativeCameraListener
-import com.yandex.mapkit.map.CameraPosition as NativeCameraPosition
-import com.yandex.mapkit.map.CameraUpdateReason as NativeCameraUpdateReason
-import com.yandex.mapkit.map.Map as NativeMap
 
-actual class CameraListener actual constructor(
-    private val onCameraPositionChanged: (
+actual abstract class CameraListener actual constructor() {
+
+    private val nativeListener = NativeCameraListener { map, cameraPosition, updateReason, finished ->
+        onCameraPositionChanged(
+            map.toCommon(),
+            cameraPosition.toCommon(),
+            updateReason.toCommon(),
+            finished
+        )
+    }
+
+    fun toNative(): CameraListener {
+        return nativeListener
+    }
+
+    actual abstract fun onCameraPositionChanged(
         map: Map,
         cameraPosition: CameraPosition,
         cameraUpdateReason: CameraUpdateReason,
         finished: Boolean,
-    ) -> Unit,
-) : NativeCameraListener {
+    )
 
-
-    override fun onCameraPositionChanged(
-        p0: NativeMap,
-        p1: NativeCameraPosition,
-        p2: NativeCameraUpdateReason,
-        p3: Boolean,
-    ) {
-        onCameraPositionChanged.invoke(p0.toCommon(), p1.toCommon(), p2.toCommon(), p3)
-    }
 }

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/CameraListener.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/CameraListener.android.kt
@@ -1,0 +1,26 @@
+package ru.sulgik.mapkit.map
+
+import com.yandex.mapkit.map.CameraListener as NativeCameraListener
+import com.yandex.mapkit.map.CameraPosition as NativeCameraPosition
+import com.yandex.mapkit.map.CameraUpdateReason as NativeCameraUpdateReason
+import com.yandex.mapkit.map.Map as NativeMap
+
+actual class CameraListener actual constructor(
+    private val onCameraPositionChanged: (
+        map: Map,
+        cameraPosition: CameraPosition,
+        cameraUpdateReason: CameraUpdateReason,
+        finished: Boolean,
+    ) -> Unit,
+) : NativeCameraListener {
+
+
+    override fun onCameraPositionChanged(
+        p0: NativeMap,
+        p1: NativeCameraPosition,
+        p2: NativeCameraUpdateReason,
+        p3: Boolean,
+    ) {
+        onCameraPositionChanged.invoke(p0.toCommon(), p1.toCommon(), p2.toCommon(), p3)
+    }
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/CameraUpdateReason.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/CameraUpdateReason.android.kt
@@ -1,0 +1,17 @@
+package ru.sulgik.mapkit.map
+
+import com.yandex.mapkit.map.CameraUpdateReason as NativeCameraUpdateReason
+
+fun NativeCameraUpdateReason.toCommon(): CameraUpdateReason {
+    return when (this) {
+        NativeCameraUpdateReason.GESTURES -> CameraUpdateReason.GESTURES
+        NativeCameraUpdateReason.APPLICATION -> CameraUpdateReason.APPLICATION
+    }
+}
+
+fun CameraUpdateReason.toNative(): NativeCameraUpdateReason {
+    return when (this) {
+        CameraUpdateReason.GESTURES -> NativeCameraUpdateReason.GESTURES
+        CameraUpdateReason.APPLICATION -> NativeCameraUpdateReason.APPLICATION
+    }
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/ClusterListener.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/ClusterListener.android.kt
@@ -4,11 +4,14 @@ import ru.sulgik.mapkit.geometry.Cluster
 import ru.sulgik.mapkit.geometry.toCommon
 import com.yandex.mapkit.map.ClusterListener as NativeClusterListener
 
-actual class ClusterListener actual constructor(private val onClusterAdded: (cluster: Cluster) -> Unit) :
-    NativeClusterListener {
+actual abstract class ClusterListener actual constructor() {
 
-    override fun onClusterAdded(p0: com.yandex.mapkit.map.Cluster) {
-        onClusterAdded(p0.toCommon())
+    private val nativeListener = NativeClusterListener { onClusterAdded(it.toCommon()) }
+
+    fun toNative(): NativeClusterListener {
+        return nativeListener
     }
+
+    actual abstract fun onClusterAdded(cluster: Cluster)
 
 }

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/ClusterTapListener.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/ClusterTapListener.android.kt
@@ -2,14 +2,18 @@ package ru.sulgik.mapkit.map
 
 import ru.sulgik.mapkit.geometry.Cluster
 import ru.sulgik.mapkit.geometry.toCommon
-import com.yandex.mapkit.map.Cluster as NativeCluster
 import com.yandex.mapkit.map.ClusterTapListener as NativeClusterTapListener
 
-actual class ClusterTapListener actual constructor(private val onClusterTap: (cluster: Cluster) -> Boolean) :
-    NativeClusterTapListener {
+actual abstract class ClusterTapListener actual constructor() {
 
-    override fun onClusterTap(p0: NativeCluster): Boolean {
-        return onClusterTap(p0.toCommon())
+    private val nativeListener = NativeClusterTapListener {
+        onClusterTap(it.toCommon())
     }
+
+    fun toNative(): NativeClusterTapListener {
+        return nativeListener
+    }
+
+    actual abstract fun onClusterTap(cluster: Cluster): Boolean
 
 }

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/ClusterizedPlacemarkCollection.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/ClusterizedPlacemarkCollection.android.kt
@@ -17,7 +17,7 @@ actual class ClusterizedPlacemarkCollection internal constructor(
     }
 
     actual fun addPlacemark(placemarkCreatedCallback: PlacemarkCreatedCallback): PlacemarkMapObject {
-        return nativeClusterizedPlacemarkCollection.addPlacemark(placemarkCreatedCallback)
+        return nativeClusterizedPlacemarkCollection.addPlacemark(placemarkCreatedCallback.toNative())
             .toCommon()
     }
 

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/InputListener.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/InputListener.android.kt
@@ -6,15 +6,28 @@ import com.yandex.mapkit.geometry.Point as NativePoint
 import com.yandex.mapkit.map.InputListener as NativeInputListener
 import com.yandex.mapkit.map.Map as NativeMap
 
-actual class InputListener actual constructor(
-    private val onMapTap: (map: Map, point: Point) -> Unit,
-    private val onMapLongTap: (map: Map, point: Point) -> Unit,
-) : NativeInputListener {
-    override fun onMapTap(p0: NativeMap, p1: NativePoint) {
-        onMapTap.invoke(p0.toCommon(), p1.toCommon())
+actual abstract class InputListener actual constructor() {
+    private val nativeListener = object : NativeInputListener {
+        override fun onMapTap(p0: NativeMap, p1: NativePoint) {
+            onMapTap(p0.toCommon(), p1.toCommon())
+        }
+
+        override fun onMapLongTap(p0: NativeMap, p1: NativePoint) {
+            onMapLongTap(p0.toCommon(), p1.toCommon())
+        }
     }
 
-    override fun onMapLongTap(p0: NativeMap, p1: NativePoint) {
-        onMapLongTap.invoke(p0.toCommon(), p1.toCommon())
+    fun toNative(): NativeInputListener {
+        return nativeListener
     }
+
+    actual abstract fun onMapTap(
+        map: Map,
+        point: Point,
+    )
+
+    actual abstract fun onMapLongTap(
+        map: Map,
+        point: Point,
+    )
 }

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/InputListener.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/InputListener.android.kt
@@ -1,0 +1,20 @@
+package ru.sulgik.mapkit.map
+
+import ru.sulgik.mapkit.geometry.Point
+import ru.sulgik.mapkit.geometry.toCommon
+import com.yandex.mapkit.geometry.Point as NativePoint
+import com.yandex.mapkit.map.InputListener as NativeInputListener
+import com.yandex.mapkit.map.Map as NativeMap
+
+actual class InputListener actual constructor(
+    private val onMapTap: (map: Map, point: Point) -> Unit,
+    private val onMapLongTap: (map: Map, point: Point) -> Unit,
+) : NativeInputListener {
+    override fun onMapTap(p0: NativeMap, p1: NativePoint) {
+        onMapTap.invoke(p0.toCommon(), p1.toCommon())
+    }
+
+    override fun onMapLongTap(p0: NativeMap, p1: NativePoint) {
+        onMapLongTap.invoke(p0.toCommon(), p1.toCommon())
+    }
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/Map.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/Map.android.kt
@@ -177,21 +177,21 @@ actual class Map internal constructor(private val nativeMap: NativeMap) {
         animation: Animation,
         cameraCallback: CameraCallback?,
     ) {
-        nativeMap.move(cameraPosition.toNative(), animation.toNative(), cameraCallback)
+        nativeMap.move(cameraPosition.toNative(), animation.toNative(), cameraCallback?.toNative())
     }
 
     /**
      * Adds camera listeners.
      */
     actual fun addCameraListener(cameraListener: CameraListener) {
-        nativeMap.addCameraListener(cameraListener)
+        nativeMap.addCameraListener(cameraListener.toNative())
     }
 
     /**
      * Removes camera listeners.
      */
     actual fun removeCameraListener(cameraListener: CameraListener) {
-        nativeMap.removeCameraListener(cameraListener)
+        nativeMap.removeCameraListener(cameraListener.toNative())
     }
 
     /**
@@ -214,14 +214,14 @@ actual class Map internal constructor(private val nativeMap: NativeMap) {
      * Adds input listeners.
      */
     actual fun addInputListener(inputListener: InputListener) {
-        nativeMap.addInputListener(inputListener)
+        nativeMap.addInputListener(inputListener.toNative())
     }
 
     /**
      * Removes input listeners.
      */
     actual fun removeInputListener(inputListener: InputListener) {
-        nativeMap.removeInputListener(inputListener)
+        nativeMap.removeInputListener(inputListener.toNative())
     }
 
 }

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/Map.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/Map.android.kt
@@ -4,6 +4,8 @@ import ru.sulgik.mapkit.Animation
 import ru.sulgik.mapkit.ScreenRect
 import ru.sulgik.mapkit.geometry.Geometry
 import ru.sulgik.mapkit.geometry.toNative
+import ru.sulgik.mapkit.logo.Logo
+import ru.sulgik.mapkit.logo.toCommon
 import ru.sulgik.mapkit.toNative
 import com.yandex.mapkit.map.Map as NativeMap
 
@@ -158,6 +160,27 @@ actual class Map internal constructor(private val nativeMap: NativeMap) {
         cameraCallback: CameraCallback?,
     ) {
         nativeMap.move(cameraPosition.toNative(), animation.toNative(), cameraCallback)
+    }
+
+    /**
+     * Adds camera listeners.
+     */
+    actual fun addCameraListener(cameraListener: CameraListener) {
+        nativeMap.addCameraListener(cameraListener)
+    }
+
+    /**
+     * Removes camera listeners.
+     */
+    actual fun removeCameraListener(cameraListener: CameraListener) {
+        nativeMap.removeCameraListener(cameraListener)
+    }
+
+    /**
+     * Yandex logo object.
+     */
+    actual fun getLogo(): Logo {
+        return nativeMap.logo.toCommon()
     }
 }
 

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/Map.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/Map.android.kt
@@ -82,6 +82,24 @@ actual class Map internal constructor(private val nativeMap: NativeMap) {
         }
 
     /**
+     * Enable/disable scroll gestures.
+     */
+    actual var isScrollGesturesEnabled: Boolean
+        get() = nativeMap.isScrollGesturesEnabled
+        set(value) {
+            nativeMap.isScrollGesturesEnabled = value
+        }
+
+    /**
+     * Enable/disable zoom gestures.
+     */
+    actual var isZoomGesturesEnabled: Boolean
+        get() = nativeMap.isZoomGesturesEnabled
+        set(value) {
+            nativeMap.isZoomGesturesEnabled = value
+        }
+
+    /**
      * Forces the map to be flat.
      *
      * true - All loaded tiles start showing the "flatten out" animation; all new tiles do not start 3D animation. false - All tiles start showing the "rise up" animation.
@@ -205,6 +223,7 @@ actual class Map internal constructor(private val nativeMap: NativeMap) {
     actual fun removeInputListener(inputListener: InputListener) {
         nativeMap.removeInputListener(inputListener)
     }
+
 }
 
 

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/Map.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/Map.android.kt
@@ -182,6 +182,29 @@ actual class Map internal constructor(private val nativeMap: NativeMap) {
     actual fun getLogo(): Logo {
         return nativeMap.logo.toCommon()
     }
+
+    /**
+     * The base map type.
+     */
+    actual var mapType: MapType
+        get() = nativeMap.mapType.toCommon()
+        set(value) {
+            nativeMap.mapType = value.toNative()
+        }
+
+    /**
+     * Adds input listeners.
+     */
+    actual fun addInputListener(inputListener: InputListener) {
+        nativeMap.addInputListener(inputListener)
+    }
+
+    /**
+     * Removes input listeners.
+     */
+    actual fun removeInputListener(inputListener: InputListener) {
+        nativeMap.removeInputListener(inputListener)
+    }
 }
 
 

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/MapObject.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/MapObject.android.kt
@@ -35,15 +35,15 @@ actual open class MapObject internal constructor(private val nativeMapObject: Na
         }
 
     actual fun addTapListener(tapListener: MapObjectTapListener) {
-        nativeMapObject.addTapListener(tapListener)
+        nativeMapObject.addTapListener(tapListener.toNative())
     }
 
     actual fun removeTapListener(tapListener: MapObjectTapListener) {
-        nativeMapObject.removeTapListener(tapListener)
+        nativeMapObject.removeTapListener(tapListener.toNative())
     }
 
     actual fun setDragListener(dragListener: MapObjectDragListener?) {
-        nativeMapObject.setDragListener(dragListener)
+        nativeMapObject.setDragListener(dragListener?.toNative())
     }
 
 }

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/MapObject.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/MapObject.android.kt
@@ -1,6 +1,11 @@
 package ru.sulgik.mapkit.map
 
+import com.yandex.mapkit.map.BaseMapObjectCollection as NativeBaseMapObjectCollection
+import com.yandex.mapkit.map.CircleMapObject as NativeCircleMapObject
 import com.yandex.mapkit.map.MapObject as NativeMapObject
+import com.yandex.mapkit.map.PlacemarkMapObject as NativePlacemarkMapObject
+import com.yandex.mapkit.map.PolygonMapObject as NativePolygonMapObject
+import com.yandex.mapkit.map.PolylineMapObject as NativePolylineMapObject
 
 actual open class MapObject internal constructor(private val nativeMapObject: NativeMapObject) {
 
@@ -44,5 +49,12 @@ actual open class MapObject internal constructor(private val nativeMapObject: Na
 }
 
 fun NativeMapObject.toCommon(): MapObject {
-    return MapObject(this)
+    return when (this) {
+        is NativeBaseMapObjectCollection -> toCommon()
+        is NativeCircleMapObject -> toCommon()
+        is NativePlacemarkMapObject -> toCommon()
+        is NativePolygonMapObject -> toCommon()
+        is NativePolylineMapObject -> toCommon()
+        else -> MapObject(this)
+    }
 }

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/MapObjectCollection.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/MapObjectCollection.android.kt
@@ -18,7 +18,7 @@ actual class MapObjectCollection internal constructor(private val nativeMapObjec
     }
 
     actual fun addPlacemark(placemarkCreatedCallback: PlacemarkCreatedCallback): PlacemarkMapObject {
-        return nativeMapObjectCollection.addPlacemark(placemarkCreatedCallback).toCommon()
+        return nativeMapObjectCollection.addPlacemark(placemarkCreatedCallback.toNative()).toCommon()
     }
 
     actual fun addPolyline(polyline: Polyline): PolylineMapObject {
@@ -38,7 +38,8 @@ actual class MapObjectCollection internal constructor(private val nativeMapObjec
     }
 
     actual fun addClusterizedPlacemarkCollection(listener: ClusterListener): ClusterizedPlacemarkCollection {
-        return nativeMapObjectCollection.addClusterizedPlacemarkCollection(listener).toCommon()
+        return nativeMapObjectCollection.addClusterizedPlacemarkCollection(listener.toNative())
+            .toCommon()
     }
 
     actual val placemarksStyler: PlacemarksStyler

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/MapObjectCollectionListener.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/MapObjectCollectionListener.android.kt
@@ -1,16 +1,23 @@
 package ru.sulgik.mapkit.map
 
+import com.yandex.mapkit.map.MapObject as NativeMapObject
 import com.yandex.mapkit.map.MapObjectCollectionListener as NativeMapObjectCollectionListener
 
-actual class MapObjectCollectionListener actual constructor(
-    val onMapObjectAdded: (mapObject: MapObject) -> Unit,
-    val onMapObjectRemoved: (mapObject: MapObject) -> Unit,
-) : NativeMapObjectCollectionListener {
-    override fun onMapObjectAdded(p0: com.yandex.mapkit.map.MapObject) {
-        onMapObjectAdded(p0.toCommon())
+actual abstract class MapObjectCollectionListener actual constructor() {
+    private val nativeListener = object : NativeMapObjectCollectionListener {
+        override fun onMapObjectAdded(p0: NativeMapObject) {
+            onMapObjectAdded(p0.toCommon())
+        }
+
+        override fun onMapObjectRemoved(p0: NativeMapObject) {
+            onMapObjectRemoved(p0.toCommon())
+        }
     }
 
-    override fun onMapObjectRemoved(p0: com.yandex.mapkit.map.MapObject) {
-        onMapObjectRemoved(p0.toCommon())
+    fun toNative(): NativeMapObjectCollectionListener {
+        return nativeListener
     }
+
+    actual abstract fun onMapObjectAdded(mapObject: MapObject)
+    actual abstract fun onMapObjectRemoved(mapObject: MapObject)
 }

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/MapObjectDragListener.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/MapObjectDragListener.android.kt
@@ -6,23 +6,26 @@ import com.yandex.mapkit.geometry.Point as NativePoint
 import com.yandex.mapkit.map.MapObject as NativeMapObject
 import com.yandex.mapkit.map.MapObjectDragListener as NativeMapObjectDragListener
 
-actual class MapObjectDragListener actual constructor(
-    private val onMapObjectDragStart: (mapObject: MapObject) -> Unit,
-    private val onMapObjectDrag: (mapObject: MapObject, point: Point) -> Unit,
-    private val onMapObjectDragEnd: (mapObject: MapObject) -> Unit,
-) : NativeMapObjectDragListener {
-    override fun onMapObjectDragStart(p0: NativeMapObject) {
-        onMapObjectDragStart(p0.toCommon())
+actual abstract class MapObjectDragListener actual constructor() {
+    private val nativeListener = object : NativeMapObjectDragListener {
+        override fun onMapObjectDragStart(p0: NativeMapObject) {
+            onMapObjectDragStart(p0.toCommon())
+        }
+
+        override fun onMapObjectDrag(p0: NativeMapObject, p1: NativePoint) {
+            onMapObjectDrag(p0.toCommon(), p1.toCommon())
+        }
+
+        override fun onMapObjectDragEnd(p0: NativeMapObject) {
+            onMapObjectDragEnd(p0.toCommon())
+        }
     }
 
-    override fun onMapObjectDrag(
-        p0: NativeMapObject,
-        p1: NativePoint,
-    ) {
-        onMapObjectDrag(p0.toCommon(), p1.toCommon())
+    fun toNative(): NativeMapObjectDragListener {
+        return nativeListener
     }
 
-    override fun onMapObjectDragEnd(p0: NativeMapObject) {
-        onMapObjectDragEnd(p0.toCommon())
-    }
+    actual abstract fun onMapObjectDragStart(mapObject: MapObject)
+    actual abstract fun onMapObjectDrag(mapObject: MapObject, point: Point)
+    actual abstract fun onMapObjectDragEnd(mapObject: MapObject)
 }

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/MapObjectTapListener.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/MapObjectTapListener.android.kt
@@ -4,14 +4,18 @@ import ru.sulgik.mapkit.geometry.Point
 import ru.sulgik.mapkit.geometry.toCommon
 import com.yandex.mapkit.map.MapObjectTapListener as NativeMapObjectTapListener
 
-actual class MapObjectTapListener actual constructor(
-    private val onMapObjectTap: (mapObject: MapObject, point: Point) -> Boolean,
-) : NativeMapObjectTapListener {
+actual abstract class MapObjectTapListener actual constructor() {
 
-    override fun onMapObjectTap(
-        p0: com.yandex.mapkit.map.MapObject,
-        p1: com.yandex.mapkit.geometry.Point,
-    ): Boolean {
-        return onMapObjectTap(p0.toCommon(), p1.toCommon())
+    private val nativeListener = NativeMapObjectTapListener { mapObject, point ->
+        onMapObjectTap(mapObject.toCommon(), point.toCommon())
     }
+
+    fun toNative(): NativeMapObjectTapListener {
+        return nativeListener
+    }
+
+    actual abstract fun onMapObjectTap(
+        mapObject: MapObject,
+        point: Point
+    ): Boolean
 }

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/MapType.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/MapType.android.kt
@@ -1,0 +1,23 @@
+package ru.sulgik.mapkit.map
+
+import com.yandex.mapkit.map.MapType as NativeMapType
+
+fun MapType.toNative(): NativeMapType {
+    return when (this) {
+        MapType.NONE -> NativeMapType.NONE
+        MapType.MAP -> NativeMapType.MAP
+        MapType.SATELLITE -> NativeMapType.SATELLITE
+        MapType.HYBRID -> NativeMapType.HYBRID
+        MapType.VECTOR_MAP -> NativeMapType.VECTOR_MAP
+    }
+}
+
+fun NativeMapType.toCommon(): MapType {
+    return when (this) {
+        NativeMapType.NONE -> MapType.NONE
+        NativeMapType.MAP -> MapType.MAP
+        NativeMapType.SATELLITE -> MapType.SATELLITE
+        NativeMapType.HYBRID -> MapType.HYBRID
+        NativeMapType.VECTOR_MAP -> MapType.VECTOR_MAP
+    }
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/MapWindow.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/MapWindow.android.kt
@@ -23,11 +23,11 @@ actual class MapWindow internal constructor(private val nativeMapWindow: MapWind
     actual val map: Map = nativeMapWindow.map.toCommon()
 
     actual fun addSizeChangeListener(listener: SizeChangeListener) {
-        nativeMapWindow.addSizeChangedListener(listener)
+        nativeMapWindow.addSizeChangedListener(listener.toNative())
     }
 
     actual fun removeSizeChangeListener(listener: SizeChangeListener) {
-        nativeMapWindow.removeSizeChangedListener(listener)
+        nativeMapWindow.removeSizeChangedListener(listener.toNative())
     }
 
 

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/PlacemarkCreatedCallback.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/PlacemarkCreatedCallback.android.kt
@@ -2,11 +2,15 @@ package ru.sulgik.mapkit.map
 
 import com.yandex.mapkit.map.PlacemarkCreatedCallback as NativePlacemarkCreatedCallback
 
-actual class PlacemarkCreatedCallback actual constructor(private val onPlacemarkCreated: (placemark: PlacemarkMapObject) -> Unit) :
-    NativePlacemarkCreatedCallback {
-
-    override fun onPlacemarkCreated(p0: com.yandex.mapkit.map.PlacemarkMapObject) {
-        onPlacemarkCreated(p0.toCommon())
+actual abstract class PlacemarkCreatedCallback actual constructor() {
+    private val nativeCallback = NativePlacemarkCreatedCallback {
+        onPlacemarkCreated(it.toCommon())
     }
+
+    fun toNative(): NativePlacemarkCreatedCallback {
+        return nativeCallback
+    }
+
+    actual abstract fun onPlacemarkCreated(placemark: PlacemarkMapObject)
 
 }

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/PlacemarkMapObject.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/PlacemarkMapObject.android.kt
@@ -44,7 +44,7 @@ actual class PlacemarkMapObject internal constructor(private val nativePlacemark
         if (onFinished != null) nativePlacemarkMapObject.setIcon(
             image.toNative(),
             style.toNative(),
-            onFinished
+            onFinished.toNative(),
         )
         else nativePlacemarkMapObject.setIcon(image.toNative(), style.toNative())
     }

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/SizeChangeListener.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/SizeChangeListener.android.kt
@@ -1,13 +1,22 @@
 package ru.sulgik.mapkit.map
 
-import com.yandex.mapkit.map.MapWindow as NativeMapWindow
 import com.yandex.mapkit.map.SizeChangedListener as NativeSizeChangedListener
 
-actual class SizeChangeListener actual constructor(
-    private val onMapWindowSizeChanged: (mapWindow: MapWindow, newWidth: Int, newHeight: Int) -> Unit,
-) :
-    NativeSizeChangedListener {
-    override fun onMapWindowSizeChanged(p0: NativeMapWindow, p1: Int, p2: Int) {
-        onMapWindowSizeChanged.invoke(p0.toCommon(), p1, p2)
+actual abstract class SizeChangeListener actual constructor() {
+
+    private val nativeListener =
+        NativeSizeChangedListener { mapWindow, newWidth, newHeight ->
+            onMapWindowSizeChanged(mapWindow.toCommon(), newWidth, newHeight)
+        }
+
+    fun toNative(): NativeSizeChangedListener {
+        return nativeListener
     }
+
+    actual abstract fun onMapWindowSizeChanged(
+        mapWindow: MapWindow,
+        newWidth: Int,
+        newHeight: Int
+    )
+
 }

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationAnchorChanged.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationAnchorChanged.android.kt
@@ -1,0 +1,21 @@
+package ru.sulgik.mapkit.user_location
+
+import ru.sulgik.mapkit.layers.ObjectEvent
+import com.yandex.mapkit.user_location.UserLocationAnchorChanged as NativeUserLocationAnchorChanged
+
+actual class UserLocationAnchorChanged internal constructor(
+    private val nativeUserLocationAnchorChanged: NativeUserLocationAnchorChanged,
+) : ObjectEvent(nativeUserLocationAnchorChanged) {
+
+    override fun toNative(): NativeUserLocationAnchorChanged {
+        return nativeUserLocationAnchorChanged
+    }
+
+    actual val anchorType: UserLocationAnchorType
+        get() = nativeUserLocationAnchorChanged.anchorType.toCommon()
+
+}
+
+fun NativeUserLocationAnchorChanged.toCommon(): UserLocationAnchorChanged {
+    return UserLocationAnchorChanged(this)
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationAnchorType.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationAnchorType.android.kt
@@ -1,0 +1,17 @@
+package ru.sulgik.mapkit.user_location
+
+import com.yandex.mapkit.user_location.UserLocationAnchorType as NativeUserLocationAnchorType
+
+fun UserLocationAnchorType.toNative(): NativeUserLocationAnchorType {
+    return when (this) {
+        UserLocationAnchorType.NORMAL -> NativeUserLocationAnchorType.NORMAL
+        UserLocationAnchorType.COURSE -> NativeUserLocationAnchorType.COURSE
+    }
+}
+
+fun NativeUserLocationAnchorType.toCommon(): UserLocationAnchorType {
+    return when (this) {
+        NativeUserLocationAnchorType.NORMAL -> UserLocationAnchorType.NORMAL
+        NativeUserLocationAnchorType.COURSE -> UserLocationAnchorType.COURSE
+    }
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationIconChanged.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationIconChanged.android.kt
@@ -1,0 +1,21 @@
+package ru.sulgik.mapkit.user_location
+
+import ru.sulgik.mapkit.layers.ObjectEvent
+import com.yandex.mapkit.user_location.UserLocationIconChanged as NativeUserLocationIconChanged
+
+actual class UserLocationIconChanged internal constructor(
+    private val nativeUserLocationIconChanged: NativeUserLocationIconChanged,
+) : ObjectEvent(nativeUserLocationIconChanged) {
+
+    override fun toNative(): NativeUserLocationIconChanged {
+        return nativeUserLocationIconChanged
+    }
+
+    actual val iconType: UserLocationIconType
+        get() = nativeUserLocationIconChanged.iconType.toCommon()
+
+}
+
+fun NativeUserLocationIconChanged.toCommon(): UserLocationIconChanged {
+    return UserLocationIconChanged(this)
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationIconType.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationIconType.android.kt
@@ -1,0 +1,17 @@
+package ru.sulgik.mapkit.user_location
+
+import com.yandex.mapkit.user_location.UserLocationIconType as NativeUserLocationIconType
+
+fun UserLocationIconType.toNative(): NativeUserLocationIconType {
+    return when (this) {
+        UserLocationIconType.ARROW -> NativeUserLocationIconType.ARROW
+        UserLocationIconType.PIN -> NativeUserLocationIconType.PIN
+    }
+}
+
+fun NativeUserLocationIconType.toCommon(): UserLocationIconType {
+    return when (this) {
+        NativeUserLocationIconType.ARROW -> UserLocationIconType.ARROW
+        NativeUserLocationIconType.PIN -> UserLocationIconType.PIN
+    }
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationLayer.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationLayer.android.kt
@@ -91,7 +91,7 @@ actual class UserLocationLayer internal constructor(private val nativeUserLocati
      * while it is attached to a class.
      */
     actual fun setTapListener(tapListener: UserLocationTapListener?) {
-        nativeUserLocationLayer.setTapListener(tapListener)
+        nativeUserLocationLayer.setTapListener(tapListener?.toNative())
     }
 
     /**
@@ -102,7 +102,7 @@ actual class UserLocationLayer internal constructor(private val nativeUserLocati
      * while it is attached to a class.
      */
     actual fun setObjectListener(objectListener: UserLocationObjectListener?) {
-        nativeUserLocationLayer.setObjectListener(objectListener)
+        nativeUserLocationLayer.setObjectListener(objectListener?.toNative())
     }
 }
 

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationLayer.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationLayer.android.kt
@@ -1,0 +1,111 @@
+package ru.sulgik.mapkit.user_location
+
+import ru.sulgik.mapkit.PointF
+import ru.sulgik.mapkit.location.LocationViewSource
+import ru.sulgik.mapkit.map.CameraPosition
+import ru.sulgik.mapkit.map.toCommon
+import ru.sulgik.mapkit.toNative
+import com.yandex.mapkit.user_location.UserLocationLayer as NativeUserLocationLayer
+
+actual class UserLocationLayer internal constructor(private val nativeUserLocationLayer: NativeUserLocationLayer) {
+
+    fun toNative(): NativeUserLocationLayer {
+        return nativeUserLocationLayer
+    }
+
+    /**
+     * User location visibility.
+     */
+    actual var isVisible: Boolean
+        get() = nativeUserLocationLayer.isVisible
+        set(value) {
+            nativeUserLocationLayer.isVisible = value
+        }
+
+    /**
+     * Heading mode.
+     */
+    actual var isHeadingEnabled: Boolean
+        get() = nativeUserLocationLayer.isHeadingEnabled
+        set(value) {
+            nativeUserLocationLayer.isHeadingEnabled = value
+        }
+
+    /**
+     * Returns true if anchor mode is set, and false otherwise.
+     */
+    actual val isAnchorEnabled: Boolean
+        get() = nativeUserLocationLayer.isAnchorEnabled
+
+    /**
+     * Auto zoom.
+     */
+    actual var isAutoZoomEnabled: Boolean
+        get() = nativeUserLocationLayer.isAutoZoomEnabled
+        set(value) {
+            nativeUserLocationLayer.isAutoZoomEnabled = value
+        }
+
+    /**
+     * Calculates the camera position that projects the current location into view.
+     */
+    actual val cameraPosition: CameraPosition?
+        get() = nativeUserLocationLayer.cameraPosition()?.toCommon()
+
+    /**
+     * Sets the anchor to the specified position in pixels and enables Anchor mode.
+     */
+    actual fun setAnchor(
+        anchorNormal: PointF,
+        anchorCourse: PointF,
+    ) {
+        nativeUserLocationLayer.setAnchor(anchorNormal.toNative(), anchorCourse.toNative())
+    }
+
+    /**
+     * Resets anchor mode.
+     */
+    actual fun resetAnchor() {
+        nativeUserLocationLayer.resetAnchor()
+    }
+
+    /**
+     * Sets/gets the data source.
+     */
+    actual fun setSource(source: LocationViewSource?) {
+        nativeUserLocationLayer.setSource(source?.toNative())
+    }
+
+    /**
+     * Sets the data source with the global location manager
+     */
+    actual fun setDefaultSource() {
+        nativeUserLocationLayer.setDefaultSource()
+    }
+
+    /**
+     * Sets/resets the tap listener.
+     *
+     * The class does not retain the object in the 'tapListener' parameter.
+     * It is your responsibility to maintain a strong reference to the target object
+     * while it is attached to a class.
+     */
+    actual fun setTapListener(tapListener: UserLocationTapListener?) {
+        nativeUserLocationLayer.setTapListener(tapListener)
+    }
+
+    /**
+     * Sets/resets the object listener.
+     *
+     * The class does not retain the object in the 'tapListener' parameter.
+     * It is your responsibility to maintain a strong reference to the target object
+     * while it is attached to a class.
+     */
+    actual fun setObjectListener(objectListener: UserLocationObjectListener?) {
+        nativeUserLocationLayer.setObjectListener(objectListener)
+    }
+}
+
+fun NativeUserLocationLayer.toCommon(): UserLocationLayer {
+    return UserLocationLayer(this)
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationObjectListener.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationObjectListener.android.kt
@@ -1,0 +1,28 @@
+package ru.sulgik.mapkit.user_location
+
+import ru.sulgik.mapkit.layers.ObjectEvent
+import ru.sulgik.mapkit.layers.toCommon
+import com.yandex.mapkit.layers.ObjectEvent as NativeObjectEvent
+import com.yandex.mapkit.user_location.UserLocationObjectListener as NativeUserLocationObjectListener
+import com.yandex.mapkit.user_location.UserLocationView as NativeUserLocationView
+
+actual class UserLocationObjectListener actual constructor(
+    private val onObjectAdded: (view: UserLocationView) -> Unit,
+    private val onObjectRemoved: (view: UserLocationView) -> Unit,
+    private val onObjectUpdated: (view: UserLocationView, event: ObjectEvent) -> Unit,
+) : NativeUserLocationObjectListener {
+    override fun onObjectAdded(p0: NativeUserLocationView) {
+        onObjectAdded.invoke(p0.toCommon())
+    }
+
+    override fun onObjectRemoved(p0: NativeUserLocationView) {
+        onObjectRemoved.invoke(p0.toCommon())
+    }
+
+    override fun onObjectUpdated(
+        p0: NativeUserLocationView,
+        p1: NativeObjectEvent,
+    ) {
+        onObjectUpdated.invoke(p0.toCommon(), p1.toCommon())
+    }
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationObjectListener.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationObjectListener.android.kt
@@ -6,23 +6,30 @@ import com.yandex.mapkit.layers.ObjectEvent as NativeObjectEvent
 import com.yandex.mapkit.user_location.UserLocationObjectListener as NativeUserLocationObjectListener
 import com.yandex.mapkit.user_location.UserLocationView as NativeUserLocationView
 
-actual class UserLocationObjectListener actual constructor(
-    private val onObjectAdded: (view: UserLocationView) -> Unit,
-    private val onObjectRemoved: (view: UserLocationView) -> Unit,
-    private val onObjectUpdated: (view: UserLocationView, event: ObjectEvent) -> Unit,
-) : NativeUserLocationObjectListener {
-    override fun onObjectAdded(p0: NativeUserLocationView) {
-        onObjectAdded.invoke(p0.toCommon())
+actual abstract class UserLocationObjectListener actual constructor() {
+
+    private val nativeListener = object : NativeUserLocationObjectListener {
+        override fun onObjectAdded(p0: NativeUserLocationView) {
+            onObjectAdded(p0.toCommon())
+        }
+
+        override fun onObjectRemoved(p0: NativeUserLocationView) {
+            onObjectRemoved(p0.toCommon())
+        }
+
+        override fun onObjectUpdated(
+            p0: NativeUserLocationView,
+            p1: NativeObjectEvent,
+        ) {
+            onObjectUpdated(p0.toCommon(), p1.toCommon())
+        }
     }
 
-    override fun onObjectRemoved(p0: NativeUserLocationView) {
-        onObjectRemoved.invoke(p0.toCommon())
+    fun toNative(): NativeUserLocationObjectListener {
+        return nativeListener
     }
 
-    override fun onObjectUpdated(
-        p0: NativeUserLocationView,
-        p1: NativeObjectEvent,
-    ) {
-        onObjectUpdated.invoke(p0.toCommon(), p1.toCommon())
-    }
+    actual abstract fun onObjectAdded(view: UserLocationView)
+    actual abstract fun onObjectRemoved(view: UserLocationView)
+    actual abstract fun onObjectUpdated(view: UserLocationView, event: ObjectEvent)
 }

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationTapListener.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationTapListener.android.kt
@@ -2,13 +2,16 @@ package ru.sulgik.mapkit.user_location
 
 import ru.sulgik.mapkit.geometry.Point
 import ru.sulgik.mapkit.geometry.toCommon
-import com.yandex.mapkit.geometry.Point as NativePoint
 import com.yandex.mapkit.user_location.UserLocationTapListener as NativeUserLocationTapListener
 
-actual class UserLocationTapListener actual constructor(
-    private val onUserLocationObjectTap: (point: Point) -> Unit,
-) : NativeUserLocationTapListener {
-    override fun onUserLocationObjectTap(p0: NativePoint) {
-        onUserLocationObjectTap.invoke(p0.toCommon())
+actual abstract class UserLocationTapListener actual constructor() {
+    private val nativeListener = NativeUserLocationTapListener {
+        onUserLocationObjectTap(it.toCommon())
     }
+
+    fun toNative(): NativeUserLocationTapListener {
+        return nativeListener
+    }
+
+    actual abstract fun onUserLocationObjectTap(point: Point)
 }

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationTapListener.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationTapListener.android.kt
@@ -1,0 +1,14 @@
+package ru.sulgik.mapkit.user_location
+
+import ru.sulgik.mapkit.geometry.Point
+import ru.sulgik.mapkit.geometry.toCommon
+import com.yandex.mapkit.geometry.Point as NativePoint
+import com.yandex.mapkit.user_location.UserLocationTapListener as NativeUserLocationTapListener
+
+actual class UserLocationTapListener actual constructor(
+    private val onUserLocationObjectTap: (point: Point) -> Unit,
+) : NativeUserLocationTapListener {
+    override fun onUserLocationObjectTap(p0: NativePoint) {
+        onUserLocationObjectTap.invoke(p0.toCommon())
+    }
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationView.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationView.android.kt
@@ -1,0 +1,25 @@
+package ru.sulgik.mapkit.user_location
+
+import ru.sulgik.mapkit.map.CircleMapObject
+import ru.sulgik.mapkit.map.PlacemarkMapObject
+import ru.sulgik.mapkit.map.toCommon
+import com.yandex.mapkit.user_location.UserLocationView as NativeUserLocationView
+
+actual class UserLocationView internal constructor(
+    private val nativeUserLocationView: NativeUserLocationView,
+) {
+    fun toNative(): NativeUserLocationView {
+        return nativeUserLocationView
+    }
+
+    actual val arrow: PlacemarkMapObject
+        get() = nativeUserLocationView.arrow.toCommon()
+    actual val pin: PlacemarkMapObject
+        get() = nativeUserLocationView.pin.toCommon()
+    actual val accuracyCircle: CircleMapObject
+        get() = nativeUserLocationView.accuracyCircle.toCommon()
+}
+
+fun NativeUserLocationView.toCommon(): UserLocationView {
+    return UserLocationView(this)
+}

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/runtime/sensors/LocationActivityType.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/runtime/sensors/LocationActivityType.android.kt
@@ -1,0 +1,21 @@
+package ru.sulgik.runtime.sensors
+
+import com.yandex.runtime.sensors.LocationActivityType as NativeLocationActivityType
+
+fun LocationActivityType.toNative(): NativeLocationActivityType {
+    return when (this) {
+        LocationActivityType.AUTO_DETECT -> NativeLocationActivityType.AUTO_DETECT
+        LocationActivityType.CAR -> NativeLocationActivityType.CAR
+        LocationActivityType.PEDESTRIAN -> NativeLocationActivityType.PEDESTRIAN
+        LocationActivityType.OTHER -> NativeLocationActivityType.OTHER
+    }
+}
+
+fun NativeLocationActivityType.toCommon(): LocationActivityType {
+    return when (this) {
+        NativeLocationActivityType.AUTO_DETECT -> LocationActivityType.AUTO_DETECT
+        NativeLocationActivityType.CAR -> LocationActivityType.CAR
+        NativeLocationActivityType.PEDESTRIAN -> LocationActivityType.PEDESTRIAN
+        NativeLocationActivityType.OTHER -> LocationActivityType.OTHER
+    }
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/MapKit.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/MapKit.kt
@@ -1,6 +1,8 @@
 package ru.sulgik.mapkit
 
 import ru.sulgik.mapkit.location.LocationManager
+import ru.sulgik.mapkit.map.MapWindow
+import ru.sulgik.mapkit.user_location.UserLocationLayer
 import ru.sulgik.runtime.sensors.LocationActivityType
 
 expect class MapKit {
@@ -41,6 +43,10 @@ expect class MapKit {
      */
     fun createLocationManager(activityType: LocationActivityType): LocationManager
 
+    /**
+     * Create layer with the user location icon.
+     */
+    fun createUserLocationLayer(mapWindow: MapWindow): UserLocationLayer
 
     companion object {
 

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/MapKit.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/MapKit.kt
@@ -1,5 +1,8 @@
 package ru.sulgik.mapkit
 
+import ru.sulgik.mapkit.location.LocationManager
+import ru.sulgik.runtime.sensors.LocationActivityType
+
 expect class MapKit {
 
     /**
@@ -22,6 +25,22 @@ expect class MapKit {
      * Notifies MapKit when the application pauses and goes to the background.
      */
     fun onStop()
+
+    /**
+     * Sets single global location manager that is used by every module in MapKit by default.
+     */
+    fun setLocationManager(locationManager: LocationManager)
+
+    /**
+     * Creates a manager that allows to listen for device location updates.
+     */
+    fun createLocationManager(): LocationManager
+
+    /**
+     * Creates a manager that allows to listen for device location updates, uses activityType as a hint.
+     */
+    fun createLocationManager(activityType: LocationActivityType): LocationManager
+
 
     companion object {
 

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/layers/ObjectEvent.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/layers/ObjectEvent.kt
@@ -1,0 +1,3 @@
+package ru.sulgik.mapkit.layers
+
+expect open class ObjectEvent

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/location/FilteringMode.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/location/FilteringMode.kt
@@ -1,0 +1,5 @@
+package ru.sulgik.mapkit.location
+
+enum class FilteringMode {
+    ON, OFF
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/location/Location.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/location/Location.kt
@@ -1,0 +1,15 @@
+package ru.sulgik.mapkit.location
+
+import kotlinx.datetime.Instant
+import ru.sulgik.mapkit.geometry.Point
+
+data class Location(
+    val position: Point,
+    val accuracy: Double?,
+    val altitude: Double?,
+    val altitudeAccuracy: Double?,
+    val heading: Double?,
+    val speed: Double?,
+    val absoluteTimestamp: Instant,
+    val relativeTimestamp: Instant,
+)

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/location/LocationListener.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/location/LocationListener.kt
@@ -1,6 +1,21 @@
 package ru.sulgik.mapkit.location
 
-expect class LocationListener(
-    onLocationUpdated: (location: Location) -> Unit,
-    onLocationStatusUpdated: (locationStatus: LocationStatus) -> Unit,
-)
+expect abstract class LocationListener() {
+    abstract fun onLocationUpdated(location: Location)
+    abstract fun onLocationStatusUpdated(locationStatus: LocationStatus)
+}
+
+inline fun LocationListener(
+    crossinline onLocationUpdated: (location: Location) -> Unit,
+    crossinline onLocationStatusUpdated: (locationStatus: LocationStatus) -> Unit,
+): LocationListener {
+    return object : LocationListener() {
+        override fun onLocationUpdated(location: Location) {
+            onLocationUpdated.invoke(location)
+        }
+
+        override fun onLocationStatusUpdated(locationStatus: LocationStatus) {
+            onLocationStatusUpdated.invoke(locationStatus)
+        }
+    }
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/location/LocationListener.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/location/LocationListener.kt
@@ -1,0 +1,6 @@
+package ru.sulgik.mapkit.location
+
+expect class LocationListener(
+    onLocationUpdated: (location: Location) -> Unit,
+    onLocationStatusUpdated: (locationStatus: LocationStatus) -> Unit,
+)

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/location/LocationManager.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/location/LocationManager.kt
@@ -1,0 +1,24 @@
+package ru.sulgik.mapkit.location
+
+import kotlin.time.Duration
+
+expect class LocationManager {
+
+    fun subscribeForLocationUpdates(
+        desiredAccuracy: Double,
+        minTime: Duration,
+        minDistance: Double,
+        allowUseInBackground: Boolean,
+        filteringMode: FilteringMode,
+        locationListener: LocationListener,
+    )
+
+    fun requestSingleUpdate(locationListener: LocationListener)
+
+    fun unsubscribe(locationListener: LocationListener)
+
+    fun suspend()
+
+    fun resume()
+
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/location/LocationStatus.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/location/LocationStatus.kt
@@ -1,0 +1,5 @@
+package ru.sulgik.mapkit.location
+
+enum class LocationStatus {
+    NOT_AVAILABLE, AVAILABLE, RESET
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/location/LocationViewSource.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/location/LocationViewSource.kt
@@ -1,0 +1,5 @@
+package ru.sulgik.mapkit.location
+
+expect class LocationViewSource
+
+expect fun LocationManager.toLocationViewSource(): LocationViewSource

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/logo/Alignment.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/logo/Alignment.kt
@@ -1,0 +1,6 @@
+package ru.sulgik.mapkit.logo
+
+data class Alignment(
+    val horizontalAlignment: HorizontalAlignment,
+    val verticalAlignment: VerticalAlignment,
+)

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/logo/HorizontalAlignment.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/logo/HorizontalAlignment.kt
@@ -1,0 +1,5 @@
+package ru.sulgik.mapkit.logo
+
+enum class HorizontalAlignment {
+    LEFT, CENTER, RIGHT,
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/logo/Logo.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/logo/Logo.kt
@@ -1,0 +1,9 @@
+package ru.sulgik.mapkit.logo
+
+expect class Logo {
+
+    fun setAlignment(alignment: Alignment)
+
+    fun setPadding(padding: Padding)
+
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/logo/Padding.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/logo/Padding.kt
@@ -1,0 +1,6 @@
+package ru.sulgik.mapkit.logo
+
+data class Padding(
+    val horizontalPadding: Int,
+    val verticalPadding: Int,
+)

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/logo/VerticalAlignment.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/logo/VerticalAlignment.kt
@@ -1,0 +1,5 @@
+package ru.sulgik.mapkit.logo
+
+enum class VerticalAlignment {
+    TOP, BOTTOM
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/Callback.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/Callback.kt
@@ -1,20 +1,13 @@
 package ru.sulgik.mapkit.map
 
 expect abstract class Callback() {
-
     abstract fun onTaskFinished()
-
 }
 
-
-private class LambdaCallback(val onTaskFinished: () -> Unit) :
-    Callback() {
-    override fun onTaskFinished() {
-        onTaskFinished.invoke()
+inline fun Callback(crossinline onTaskFinished: () -> Unit): Callback {
+    return object : Callback() {
+        override fun onTaskFinished() {
+            onTaskFinished.invoke()
+        }
     }
-
-}
-
-fun Callback(onTaskFinished: () -> Unit): Callback {
-    return LambdaCallback(onTaskFinished)
 }

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/CameraCallback.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/CameraCallback.kt
@@ -1,20 +1,13 @@
 package ru.sulgik.mapkit.map
 
 expect abstract class CameraCallback() {
-
     abstract fun onMoveFinished(completed: Boolean)
-
 }
 
-private class LambdaCameraCallback(val onMoveFinished: (completed: Boolean) -> Unit) :
-    CameraCallback() {
-
-    override fun onMoveFinished(completed: Boolean) {
-        onMoveFinished.invoke(completed)
+inline fun CameraCallback(crossinline onMoveFinished: (completed: Boolean) -> Unit): CameraCallback {
+    return object : CameraCallback() {
+        override fun onMoveFinished(completed: Boolean) {
+            onMoveFinished.invoke(completed)
+        }
     }
-
-}
-
-fun CameraCallback(onMoveFinished: (completed: Boolean) -> Unit): CameraCallback {
-    return LambdaCameraCallback(onMoveFinished)
 }

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/CameraListener.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/CameraListener.kt
@@ -1,0 +1,10 @@
+package ru.sulgik.mapkit.map
+
+expect class CameraListener(
+    onCameraPositionChanged: (
+        map: Map,
+        cameraPosition: CameraPosition,
+        cameraUpdateReason: CameraUpdateReason,
+        finished: Boolean,
+    ) -> Unit,
+)

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/CameraListener.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/CameraListener.kt
@@ -1,10 +1,30 @@
 package ru.sulgik.mapkit.map
 
-expect class CameraListener(
-    onCameraPositionChanged: (
+expect abstract class CameraListener() {
+    abstract fun onCameraPositionChanged(
+        map: Map,
+        cameraPosition: CameraPosition,
+        cameraUpdateReason: CameraUpdateReason,
+        finished: Boolean,
+    )
+}
+
+inline fun CameraListener(
+    crossinline onCameraPositionChanged: (
         map: Map,
         cameraPosition: CameraPosition,
         cameraUpdateReason: CameraUpdateReason,
         finished: Boolean,
     ) -> Unit,
-)
+): CameraListener {
+    return object : CameraListener() {
+        override fun onCameraPositionChanged(
+            map: Map,
+            cameraPosition: CameraPosition,
+            cameraUpdateReason: CameraUpdateReason,
+            finished: Boolean,
+        ) {
+            onCameraPositionChanged.invoke(map, cameraPosition, cameraUpdateReason, finished)
+        }
+    }
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/CameraUpdateReason.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/CameraUpdateReason.kt
@@ -1,0 +1,5 @@
+package ru.sulgik.mapkit.map
+
+enum class CameraUpdateReason {
+    GESTURES, APPLICATION
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/ClusterListener.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/ClusterListener.kt
@@ -2,4 +2,16 @@ package ru.sulgik.mapkit.map
 
 import ru.sulgik.mapkit.geometry.Cluster
 
-expect class ClusterListener(onClusterAdded: (cluster: Cluster) -> Unit)
+expect abstract class ClusterListener() {
+
+    abstract fun onClusterAdded(cluster: Cluster)
+
+}
+
+inline fun ClusterListener(crossinline onClusterAdded: (cluster: Cluster) -> Unit): ClusterListener {
+    return object : ClusterListener() {
+        override fun onClusterAdded(cluster: Cluster) {
+            onClusterAdded.invoke(cluster)
+        }
+    }
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/ClusterTapListener.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/ClusterTapListener.kt
@@ -2,4 +2,16 @@ package ru.sulgik.mapkit.map
 
 import ru.sulgik.mapkit.geometry.Cluster
 
-expect class ClusterTapListener(onClusterTap: (cluster: Cluster) -> Boolean)
+expect abstract class ClusterTapListener() {
+
+    abstract fun onClusterTap(cluster: Cluster): Boolean
+
+}
+
+inline fun ClusterTapListener(crossinline onClusterTap: (cluster: Cluster) -> Boolean): ClusterTapListener {
+    return object : ClusterTapListener() {
+        override fun onClusterTap(cluster: Cluster): Boolean {
+            return onClusterTap.invoke(cluster)
+        }
+    }
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/InputListener.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/InputListener.kt
@@ -2,13 +2,23 @@ package ru.sulgik.mapkit.map
 
 import ru.sulgik.mapkit.geometry.Point
 
-expect class InputListener(
-    onMapTap: (
-        map: Map,
-        point: Point,
-    ) -> Unit,
-    onMapLongTap: (
-        map: Map,
-        point: Point,
-    ) -> Unit,
-)
+expect abstract class InputListener() {
+    abstract fun onMapTap(map: Map, point: Point)
+    abstract fun onMapLongTap(map: Map, point: Point)
+}
+
+inline fun InputListener(
+    crossinline onMapTap: (map: Map, point: Point) -> Unit,
+    crossinline onMapLongTap: (map: Map, point: Point) -> Unit,
+): InputListener {
+    return object : InputListener() {
+        override fun onMapTap(map: Map, point: Point) {
+            onMapTap.invoke(map, point)
+        }
+
+        override fun onMapLongTap(map: Map, point: Point) {
+            onMapLongTap.invoke(map, point)
+        }
+
+    }
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/InputListener.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/InputListener.kt
@@ -1,0 +1,14 @@
+package ru.sulgik.mapkit.map
+
+import ru.sulgik.mapkit.geometry.Point
+
+expect class InputListener(
+    onMapTap: (
+        map: Map,
+        point: Point,
+    ) -> Unit,
+    onMapLongTap: (
+        map: Map,
+        point: Point,
+    ) -> Unit,
+)

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/Map.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/Map.kt
@@ -3,6 +3,7 @@ package ru.sulgik.mapkit.map
 import ru.sulgik.mapkit.Animation
 import ru.sulgik.mapkit.ScreenRect
 import ru.sulgik.mapkit.geometry.Geometry
+import ru.sulgik.mapkit.logo.Logo
 
 expect class Map {
 
@@ -110,5 +111,20 @@ expect class Map {
         animation: Animation,
         cameraCallback: CameraCallback? = null,
     )
+
+    /**
+     * Adds camera listeners.
+     */
+    fun addCameraListener(cameraListener: CameraListener)
+
+    /**
+     * Removes camera listeners.
+     */
+    fun removeCameraListener(cameraListener: CameraListener)
+
+    /**
+     * Yandex logo object.
+     */
+    fun getLogo(): Logo
 
 }

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/Map.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/Map.kt
@@ -51,6 +51,11 @@ expect class Map {
     var isTiltGesturesEnabled: Boolean
 
     /**
+     * The base map type.
+     */
+    var mapType: MapType
+
+    /**
      * Forces the map to be flat.
      *
      * true - All loaded tiles start showing the "flatten out" animation; all new tiles do not start 3D animation. false - All tiles start showing the "rise up" animation.
@@ -127,4 +132,14 @@ expect class Map {
      */
     fun getLogo(): Logo
 
+    /**
+     * Adds input listeners.
+     */
+    fun addInputListener(inputListener: InputListener)
+
+    /**
+     * Removes input listeners.
+     */
+    fun removeInputListener(inputListener: InputListener)
+    
 }

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/Map.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/Map.kt
@@ -51,6 +51,16 @@ expect class Map {
     var isTiltGesturesEnabled: Boolean
 
     /**
+     * Enable/disable scroll gestures.
+     */
+    var isScrollGesturesEnabled: Boolean
+
+    /**
+     * Enable/disable zoom gestures.
+     */
+    var isZoomGesturesEnabled: Boolean
+
+    /**
      * The base map type.
      */
     var mapType: MapType

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/MapObjectCollectionListener.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/MapObjectCollectionListener.kt
@@ -1,6 +1,21 @@
 package ru.sulgik.mapkit.map
 
-expect class MapObjectCollectionListener(
-    onMapObjectAdded: (mapObject: MapObject) -> Unit,
-    onMapObjectRemoved: (mapObject: MapObject) -> Unit,
-)
+expect abstract class MapObjectCollectionListener() {
+    abstract fun onMapObjectAdded(mapObject: MapObject)
+    abstract fun onMapObjectRemoved(mapObject: MapObject)
+}
+
+inline fun MapObjectCollectionListener(
+    crossinline onMapObjectAdded: (mapObject: MapObject) -> Unit,
+    crossinline onMapObjectRemoved: (mapObject: MapObject) -> Unit,
+): MapObjectCollectionListener {
+    return object : MapObjectCollectionListener() {
+        override fun onMapObjectAdded(mapObject: MapObject) {
+            onMapObjectAdded.invoke(mapObject)
+        }
+
+        override fun onMapObjectRemoved(mapObject: MapObject) {
+            onMapObjectRemoved.invoke(mapObject)
+        }
+    }
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/MapObjectDragListener.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/MapObjectDragListener.kt
@@ -2,8 +2,29 @@ package ru.sulgik.mapkit.map
 
 import ru.sulgik.mapkit.geometry.Point
 
-expect class MapObjectDragListener(
-    onMapObjectDragStart: (mapObject: MapObject) -> Unit,
-    onMapObjectDrag: (mapObject: MapObject, point: Point) -> Unit,
-    onMapObjectDragEnd: (mapObject: MapObject) -> Unit,
-)
+expect abstract class MapObjectDragListener() {
+    abstract fun onMapObjectDragStart(mapObject: MapObject)
+    abstract fun onMapObjectDrag(mapObject: MapObject, point: Point)
+    abstract fun onMapObjectDragEnd(mapObject: MapObject)
+}
+
+inline fun MapObjectDragListener(
+    crossinline onMapObjectDragStart: (mapObject: MapObject) -> Unit,
+    crossinline onMapObjectDrag: (mapObject: MapObject, point: Point) -> Unit,
+    crossinline onMapObjectDragEnd: (mapObject: MapObject) -> Unit,
+): MapObjectDragListener {
+    return object : MapObjectDragListener() {
+        override fun onMapObjectDragStart(mapObject: MapObject) {
+            onMapObjectDragStart.invoke(mapObject)
+        }
+
+        override fun onMapObjectDrag(mapObject: MapObject, point: Point) {
+            onMapObjectDrag.invoke(mapObject, point)
+        }
+
+        override fun onMapObjectDragEnd(mapObject: MapObject) {
+            onMapObjectDragEnd.invoke(mapObject)
+        }
+
+    }
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/MapObjectTapListener.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/MapObjectTapListener.kt
@@ -2,4 +2,16 @@ package ru.sulgik.mapkit.map
 
 import ru.sulgik.mapkit.geometry.Point
 
-expect class MapObjectTapListener(onMapObjectTap: (mapObject: MapObject, point: Point) -> Boolean)
+expect abstract class MapObjectTapListener() {
+    abstract fun onMapObjectTap(mapObject: MapObject, point: Point): Boolean
+}
+
+inline fun MapObjectTapListener(
+    crossinline onMapObjectTap: (mapObject: MapObject, point: Point) -> Boolean
+): MapObjectTapListener {
+    return object : MapObjectTapListener() {
+        override fun onMapObjectTap(mapObject: MapObject, point: Point): Boolean {
+            return onMapObjectTap.invoke(mapObject, point)
+        }
+    }
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/MapType.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/MapType.kt
@@ -1,0 +1,28 @@
+package ru.sulgik.mapkit.map
+
+enum class MapType {
+    /**
+     * Do not use any of the predefined maps.
+     */
+    NONE,
+
+    /**
+     * Raster map.
+     */
+    MAP,
+
+    /**
+     * Allowed only for Yandex apps Default satellite map.
+     */
+    SATELLITE,
+
+    /**
+     * Allowed only for Yandex apps Satellite map with roads, placemarks and labels.
+     */
+    HYBRID,
+
+    /**
+     * Vector map.
+     */
+    VECTOR_MAP,
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/PlacemarkCreatedCallback.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/PlacemarkCreatedCallback.kt
@@ -1,3 +1,15 @@
 package ru.sulgik.mapkit.map
 
-expect class PlacemarkCreatedCallback(onPlacemarkCreated: (placemark: PlacemarkMapObject) -> Unit)
+expect abstract class PlacemarkCreatedCallback() {
+    abstract fun onPlacemarkCreated(placemark: PlacemarkMapObject)
+}
+
+inline fun PlacemarkCreatedCallback(
+    crossinline onPlacemarkCreated: (placemark: PlacemarkMapObject) -> Unit
+): PlacemarkCreatedCallback {
+    return object : PlacemarkCreatedCallback() {
+        override fun onPlacemarkCreated(placemark: PlacemarkMapObject) {
+            onPlacemarkCreated.invoke(placemark)
+        }
+    }
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/SizeChangeListener.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/SizeChangeListener.kt
@@ -1,5 +1,15 @@
 package ru.sulgik.mapkit.map
 
-expect class SizeChangeListener(
-    onMapWindowSizeChanged: (mapWindow: MapWindow, newWidth: Int, newHeight: Int) -> Unit,
-)
+expect abstract class SizeChangeListener() {
+    abstract fun onMapWindowSizeChanged(mapWindow: MapWindow, newWidth: Int, newHeight: Int)
+}
+
+inline fun SizeChangeListener(
+   crossinline onMapWindowSizeChanged: (mapWindow: MapWindow, newWidth: Int, newHeight: Int) -> Unit,
+): SizeChangeListener {
+    return object : SizeChangeListener() {
+        override fun onMapWindowSizeChanged(mapWindow: MapWindow, newWidth: Int, newHeight: Int) {
+            onMapWindowSizeChanged.invoke(mapWindow, newWidth, newHeight)
+        }
+    }
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationAnchorChanged.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationAnchorChanged.kt
@@ -1,0 +1,9 @@
+package ru.sulgik.mapkit.user_location
+
+import ru.sulgik.mapkit.layers.ObjectEvent
+
+expect class UserLocationAnchorChanged: ObjectEvent {
+
+    val anchorType: UserLocationAnchorType
+
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationAnchorType.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationAnchorType.kt
@@ -1,0 +1,5 @@
+package ru.sulgik.mapkit.user_location
+
+enum class UserLocationAnchorType {
+    NORMAL, COURSE
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationIconChanged.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationIconChanged.kt
@@ -1,0 +1,9 @@
+package ru.sulgik.mapkit.user_location
+
+import ru.sulgik.mapkit.layers.ObjectEvent
+
+expect class UserLocationIconChanged: ObjectEvent {
+
+    val iconType: UserLocationIconType
+
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationIconType.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationIconType.kt
@@ -1,0 +1,5 @@
+package ru.sulgik.mapkit.user_location
+
+enum class UserLocationIconType {
+    ARROW, PIN
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationLayer.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationLayer.kt
@@ -1,0 +1,76 @@
+package ru.sulgik.mapkit.user_location
+
+import ru.sulgik.mapkit.PointF
+import ru.sulgik.mapkit.location.LocationViewSource
+import ru.sulgik.mapkit.map.CameraPosition
+
+expect class UserLocationLayer {
+
+    /**
+     * User location visibility.
+     */
+    var isVisible: Boolean
+
+    /**
+     * Heading mode.
+     */
+    var isHeadingEnabled: Boolean
+
+
+    /**
+     * Returns true if anchor mode is set, and false otherwise.
+     */
+    val isAnchorEnabled: Boolean
+
+    /**
+     * Auto zoom.
+     */
+    var isAutoZoomEnabled: Boolean
+
+    /**
+     * Calculates the camera position that projects the current location into view.
+     */
+    val cameraPosition: CameraPosition?
+
+    /**
+     * Sets the anchor to the specified position in pixels and enables Anchor mode.
+     */
+    fun setAnchor(
+        anchorNormal: PointF,
+        anchorCourse: PointF,
+    )
+
+    /**
+     * Resets anchor mode.
+     */
+    fun resetAnchor()
+
+    /**
+     * Sets/gets the data source.
+     */
+    fun setSource(source: LocationViewSource?)
+
+    /**
+     * Sets the data source with the global location manager
+     */
+    fun setDefaultSource()
+
+    /**
+     * Sets/resets the tap listener.
+     *
+     * The class does not retain the object in the 'tapListener' parameter.
+     * It is your responsibility to maintain a strong reference to the target object
+     * while it is attached to a class.
+     */
+    fun setTapListener(tapListener: UserLocationTapListener?)
+
+    /**
+     * Sets/resets the object listener.
+     *
+     * The class does not retain the object in the 'tapListener' parameter.
+     * It is your responsibility to maintain a strong reference to the target object
+     * while it is attached to a class.
+     */
+    fun setObjectListener(objectListener: UserLocationObjectListener?)
+
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationObjectListener.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationObjectListener.kt
@@ -2,8 +2,33 @@ package ru.sulgik.mapkit.user_location
 
 import ru.sulgik.mapkit.layers.ObjectEvent
 
-expect class UserLocationObjectListener(
-    onObjectAdded: (view: UserLocationView) -> Unit,
-    onObjectRemoved: (view: UserLocationView) -> Unit,
-    onObjectUpdated: (view: UserLocationView, event: ObjectEvent) -> Unit,
-)
+expect abstract class UserLocationObjectListener() {
+
+    abstract fun onObjectAdded(view: UserLocationView)
+
+    abstract fun onObjectRemoved(view: UserLocationView)
+
+    abstract fun onObjectUpdated(view: UserLocationView, event: ObjectEvent)
+
+}
+
+inline fun UserLocationObjectListener(
+    crossinline onObjectAdded: (view: UserLocationView) -> Unit,
+    crossinline onObjectRemoved: (view: UserLocationView) -> Unit,
+    crossinline onObjectUpdated: (view: UserLocationView, event: ObjectEvent) -> Unit,
+): UserLocationObjectListener {
+    return object : UserLocationObjectListener() {
+        override fun onObjectAdded(view: UserLocationView) {
+            onObjectAdded.invoke(view)
+        }
+
+        override fun onObjectRemoved(view: UserLocationView) {
+            onObjectRemoved.invoke(view)
+        }
+
+        override fun onObjectUpdated(view: UserLocationView, event: ObjectEvent) {
+            onObjectUpdated.invoke(view, event)
+        }
+
+    }
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationObjectListener.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationObjectListener.kt
@@ -1,0 +1,9 @@
+package ru.sulgik.mapkit.user_location
+
+import ru.sulgik.mapkit.layers.ObjectEvent
+
+expect class UserLocationObjectListener(
+    onObjectAdded: (view: UserLocationView) -> Unit,
+    onObjectRemoved: (view: UserLocationView) -> Unit,
+    onObjectUpdated: (view: UserLocationView, event: ObjectEvent) -> Unit,
+)

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationTapListener.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationTapListener.kt
@@ -2,6 +2,16 @@ package ru.sulgik.mapkit.user_location
 
 import ru.sulgik.mapkit.geometry.Point
 
-expect class UserLocationTapListener(
-    onUserLocationObjectTap: (point: Point) -> Unit,
-)
+expect abstract class UserLocationTapListener() {
+    abstract fun onUserLocationObjectTap(point: Point)
+}
+
+inline fun UserLocationTapListener(
+    crossinline onUserLocationObjectTap: (point: Point) -> Unit,
+): UserLocationTapListener {
+    return object : UserLocationTapListener() {
+        override fun onUserLocationObjectTap(point: Point) {
+            onUserLocationObjectTap.invoke(point)
+        }
+    }
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationTapListener.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationTapListener.kt
@@ -1,0 +1,7 @@
+package ru.sulgik.mapkit.user_location
+
+import ru.sulgik.mapkit.geometry.Point
+
+expect class UserLocationTapListener(
+    onUserLocationObjectTap: (point: Point) -> Unit,
+)

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationView.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationView.kt
@@ -1,0 +1,10 @@
+package ru.sulgik.mapkit.user_location
+
+import ru.sulgik.mapkit.map.CircleMapObject
+import ru.sulgik.mapkit.map.PlacemarkMapObject
+
+expect class UserLocationView{
+    val arrow: PlacemarkMapObject
+    val pin: PlacemarkMapObject
+    val accuracyCircle: CircleMapObject
+}

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/runtime/sensors/LocationActivityType.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/runtime/sensors/LocationActivityType.kt
@@ -1,0 +1,8 @@
+package ru.sulgik.runtime.sensors
+
+enum class LocationActivityType {
+    AUTO_DETECT,
+    CAR,
+    PEDESTRIAN,
+    OTHER
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/MapKit.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/MapKit.ios.kt
@@ -7,26 +7,17 @@ import YandexMapKit.setLocale
 import YandexMapKit.setUserId
 import YandexMapKit.sharedInstance
 import kotlinx.cinterop.ExperimentalForeignApi
+import ru.sulgik.mapkit.location.LocationManager
+import ru.sulgik.mapkit.location.toCommon
+import ru.sulgik.runtime.sensors.LocationActivityType
+import ru.sulgik.runtime.sensors.toNative
 import YandexMapKit.YMKMapKit as NativeMapKit
 
 actual class MapKit internal constructor(private val nativeMapKit: NativeMapKit) {
 
-    actual companion object {
-        actual fun setApiKey(apiKey: String) {
-            NativeMapKit.setApiKey(apiKey)
-        }
+    fun toNative(): NativeMapKit {
+        return nativeMapKit
 
-        actual fun getInstance(): MapKit {
-            return NativeMapKit.sharedInstance().toCommon()
-        }
-
-        actual fun setLocale(locale: String?) {
-            NativeMapKit.setLocale(locale)
-        }
-
-        actual fun setUserId(userId: String) {
-            NativeMapKit.setUserId(userId)
-        }
     }
 
     /**
@@ -56,6 +47,45 @@ actual class MapKit internal constructor(private val nativeMapKit: NativeMapKit)
         nativeMapKit.onStop()
     }
 
+    /**
+     * Sets single global location manager that is used by every module in MapKit by default.
+     */
+    actual fun setLocationManager(locationManager: LocationManager) {
+        nativeMapKit.setLocationManagerWithLocationManager(locationManager.toNative())
+    }
+
+    /**
+     * Creates a manager that allows to listen for device location updates.
+     */
+    actual fun createLocationManager(): LocationManager {
+        return nativeMapKit.createLocationManager().toCommon()
+    }
+
+    /**
+     * Creates a manager that allows to listen for device location updates, uses activityType as a hint.
+     */
+    actual fun createLocationManager(activityType: LocationActivityType): LocationManager {
+        return nativeMapKit.createLocationManagerWithActivityType(activityType.toNative())
+            .toCommon()
+    }
+
+    actual companion object {
+        actual fun setApiKey(apiKey: String) {
+            NativeMapKit.setApiKey(apiKey)
+        }
+
+        actual fun getInstance(): MapKit {
+            return NativeMapKit.sharedInstance().toCommon()
+        }
+
+        actual fun setLocale(locale: String?) {
+            NativeMapKit.setLocale(locale)
+        }
+
+        actual fun setUserId(userId: String) {
+            NativeMapKit.setUserId(userId)
+        }
+    }
 }
 
 fun NativeMapKit.toCommon(): MapKit {

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/MapKit.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/MapKit.ios.kt
@@ -9,6 +9,9 @@ import YandexMapKit.sharedInstance
 import kotlinx.cinterop.ExperimentalForeignApi
 import ru.sulgik.mapkit.location.LocationManager
 import ru.sulgik.mapkit.location.toCommon
+import ru.sulgik.mapkit.map.MapWindow
+import ru.sulgik.mapkit.user_location.UserLocationLayer
+import ru.sulgik.mapkit.user_location.toCommon
 import ru.sulgik.runtime.sensors.LocationActivityType
 import ru.sulgik.runtime.sensors.toNative
 import YandexMapKit.YMKMapKit as NativeMapKit
@@ -67,6 +70,13 @@ actual class MapKit internal constructor(private val nativeMapKit: NativeMapKit)
     actual fun createLocationManager(activityType: LocationActivityType): LocationManager {
         return nativeMapKit.createLocationManagerWithActivityType(activityType.toNative())
             .toCommon()
+    }
+
+    /**
+     * Create layer with the user location icon.
+     */
+    actual fun createUserLocationLayer(mapWindow: MapWindow): UserLocationLayer {
+        return nativeMapKit.createUserLocationLayerWithMapWindow(mapWindow.toNative()).toCommon()
     }
 
     actual companion object {

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/NSNubler.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/NSNubler.ios.kt
@@ -1,0 +1,28 @@
+package ru.sulgik.mapkit
+
+import platform.Foundation.NSNumber
+import platform.Foundation.numberWithBool
+import platform.Foundation.numberWithDouble
+import platform.Foundation.numberWithFloat
+import platform.Foundation.numberWithInt
+import platform.Foundation.numberWithLong
+
+fun Int.toNSNumber(): NSNumber {
+    return NSNumber.numberWithInt(this)
+}
+
+fun Long.toNSNumber(): NSNumber {
+    return NSNumber.numberWithLong(this)
+}
+
+fun Boolean.toNSNumber(): NSNumber {
+    return NSNumber.numberWithBool(this)
+}
+
+fun Float.toNSNumber(): NSNumber {
+    return NSNumber.numberWithFloat(this)
+}
+
+fun Double.toNSNumber(): NSNumber {
+    return NSNumber.numberWithDouble(this)
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/geometry/Cluster.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/geometry/Cluster.ios.kt
@@ -21,11 +21,11 @@ actual class Cluster internal constructor(private val nativeCluster: NativeClust
         get() = nativeCluster.appearance.toCommon()
 
     actual fun addClusterTapListener(listener: ClusterTapListener) {
-        nativeCluster.addClusterTapListenerWithClusterTapListener(listener)
+        nativeCluster.addClusterTapListenerWithClusterTapListener(listener.toNative())
     }
 
     actual fun removeClusterTapListener(listener: ClusterTapListener) {
-        nativeCluster.removeClusterTapListenerWithClusterTapListener(listener)
+        nativeCluster.removeClusterTapListenerWithClusterTapListener(listener.toNative())
     }
 
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/layers/ObjectEvent.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/layers/ObjectEvent.ios.kt
@@ -1,0 +1,23 @@
+package ru.sulgik.mapkit.layers
+
+import ru.sulgik.mapkit.user_location.toCommon
+import YandexMapKit.YMKObjectEvent as NativeObjectEvent
+import YandexMapKit.YMKUserLocationAnchorChanged as NativeUserLocationAnchorChanged
+import YandexMapKit.YMKUserLocationIconChanged as NativeUserLocationIconChanged
+
+actual open class ObjectEvent internal constructor(private val nativeObjectEvent: NativeObjectEvent) {
+
+    open fun toNative(): NativeObjectEvent {
+        return nativeObjectEvent
+    }
+
+}
+
+fun NativeObjectEvent.toCommon(): ObjectEvent {
+    return when (this) {
+        is NativeUserLocationAnchorChanged -> toCommon()
+        is NativeUserLocationIconChanged -> toCommon()
+        else -> ObjectEvent(this)
+    }
+}
+

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/location/FilteringMode.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/location/FilteringMode.ios.kt
@@ -1,0 +1,18 @@
+package ru.sulgik.mapkit.location
+
+import YandexMapKit.YMKLocationFilteringMode as NativeFilteringMode
+
+fun FilteringMode.toNative(): NativeFilteringMode {
+    return when (this) {
+        FilteringMode.ON -> NativeFilteringMode.YMKLocationFilteringModeOn
+        FilteringMode.OFF -> NativeFilteringMode.YMKLocationFilteringModeOff
+    }
+}
+
+fun NativeFilteringMode.toCommon(): FilteringMode {
+    return when (this) {
+        NativeFilteringMode.YMKLocationFilteringModeOn -> FilteringMode.ON
+        NativeFilteringMode.YMKLocationFilteringModeOff -> FilteringMode.OFF
+        else -> throw IllegalArgumentException("Unknown NativeFilteringMode ($this)")
+    }
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/location/Location.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/location/Location.ios.kt
@@ -1,0 +1,34 @@
+package ru.sulgik.mapkit.location
+
+import kotlinx.datetime.toKotlinInstant
+import kotlinx.datetime.toNSDate
+import ru.sulgik.mapkit.geometry.toCommon
+import ru.sulgik.mapkit.geometry.toNative
+import ru.sulgik.mapkit.toNSNumber
+import YandexMapKit.YMKLocation as NativeLocation
+
+fun Location.toNative(): NativeLocation {
+    return NativeLocation.locationWithPosition(
+        position = position.toNative(),
+        accuracy = accuracy?.toNSNumber(),
+        altitude = altitude?.toNSNumber(),
+        altitudeAccuracy = altitudeAccuracy?.toNSNumber(),
+        heading = heading?.toNSNumber(),
+        speed = speed?.toNSNumber(),
+        absoluteTimestamp = absoluteTimestamp.toNSDate(),
+        relativeTimestamp = relativeTimestamp.toNSDate(),
+    )
+}
+
+fun NativeLocation.toCommon(): Location {
+    return Location(
+        position = position.toCommon(),
+        accuracy = accuracy?.doubleValue,
+        altitude = altitude?.doubleValue,
+        altitudeAccuracy = altitudeAccuracy?.doubleValue,
+        heading = heading?.doubleValue,
+        speed = speed?.doubleValue,
+        absoluteTimestamp = absoluteTimestamp.toKotlinInstant(),
+        relativeTimestamp = relativeTimestamp.toKotlinInstant(),
+    )
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/location/LocationListener.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/location/LocationListener.ios.kt
@@ -5,16 +5,22 @@ import YandexMapKit.YMKLocation as NativeLocation
 import YandexMapKit.YMKLocationDelegateProtocol as NativeLocationListener
 import YandexMapKit.YMKLocationStatus as NativeLocationStatus
 
-actual class LocationListener actual constructor(
-    private val onLocationUpdated: (location: Location) -> Unit,
-    private val onLocationStatusUpdated: (locationStatus: LocationStatus) -> Unit,
-) : NativeLocationListener, NSObject() {
+actual abstract class LocationListener actual constructor() {
 
-    override fun onLocationStatusUpdatedWithStatus(status: NativeLocationStatus) {
-        onLocationStatusUpdated.invoke(status.toCommon())
+    private val nativeListener  = object : NativeLocationListener, NSObject() {
+        override fun onLocationStatusUpdatedWithStatus(status: NativeLocationStatus) {
+            onLocationStatusUpdated(status.toCommon())
+        }
+
+        override fun onLocationUpdatedWithLocation(location: NativeLocation) {
+            onLocationUpdated(location.toCommon())
+        }
     }
 
-    override fun onLocationUpdatedWithLocation(location: NativeLocation) {
-        onLocationUpdated.invoke(location.toCommon())
+    fun toNative(): NativeLocationListener {
+        return nativeListener
     }
+
+    actual abstract fun onLocationUpdated(location: Location)
+    actual abstract fun onLocationStatusUpdated(locationStatus: LocationStatus)
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/location/LocationListener.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/location/LocationListener.ios.kt
@@ -1,0 +1,20 @@
+package ru.sulgik.mapkit.location
+
+import platform.darwin.NSObject
+import YandexMapKit.YMKLocation as NativeLocation
+import YandexMapKit.YMKLocationDelegateProtocol as NativeLocationListener
+import YandexMapKit.YMKLocationStatus as NativeLocationStatus
+
+actual class LocationListener actual constructor(
+    private val onLocationUpdated: (location: Location) -> Unit,
+    private val onLocationStatusUpdated: (locationStatus: LocationStatus) -> Unit,
+) : NativeLocationListener, NSObject() {
+
+    override fun onLocationStatusUpdatedWithStatus(status: NativeLocationStatus) {
+        onLocationStatusUpdated.invoke(status.toCommon())
+    }
+
+    override fun onLocationUpdatedWithLocation(location: NativeLocation) {
+        onLocationUpdated.invoke(location.toCommon())
+    }
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/location/LocationManager.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/location/LocationManager.ios.kt
@@ -1,0 +1,50 @@
+package ru.sulgik.mapkit.location
+
+import kotlin.time.Duration
+import YandexMapKit.YMKLocationManager as NativeLocationManager
+
+actual class LocationManager(private val nativeLocationManager: NativeLocationManager) {
+
+    fun toNative(): NativeLocationManager {
+        return nativeLocationManager
+    }
+
+    actual fun subscribeForLocationUpdates(
+        desiredAccuracy: Double,
+        minTime: Duration,
+        minDistance: Double,
+        allowUseInBackground: Boolean,
+        filteringMode: FilteringMode,
+        locationListener: LocationListener,
+    ) {
+        nativeLocationManager.subscribeForLocationUpdatesWithDesiredAccuracy(
+            desiredAccuracy = desiredAccuracy,
+            minTime = minTime.inWholeMilliseconds,
+            minDistance = minDistance,
+            allowUseInBackground = allowUseInBackground,
+            filteringMode = filteringMode.toNative(),
+            locationListener = locationListener,
+        )
+    }
+
+    actual fun suspend() {
+        nativeLocationManager.suspend()
+    }
+
+    actual fun resume() {
+        nativeLocationManager.resume()
+    }
+
+    actual fun requestSingleUpdate(locationListener: LocationListener) {
+        nativeLocationManager.requestSingleUpdateWithLocationListener(locationListener)
+    }
+
+    actual fun unsubscribe(locationListener: LocationListener) {
+        nativeLocationManager.unsubscribeWithLocationListener(locationListener)
+    }
+
+}
+
+fun NativeLocationManager.toCommon(): LocationManager {
+    return LocationManager(this)
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/location/LocationManager.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/location/LocationManager.ios.kt
@@ -23,7 +23,7 @@ actual class LocationManager(private val nativeLocationManager: NativeLocationMa
             minDistance = minDistance,
             allowUseInBackground = allowUseInBackground,
             filteringMode = filteringMode.toNative(),
-            locationListener = locationListener,
+            locationListener = locationListener.toNative(),
         )
     }
 
@@ -36,11 +36,11 @@ actual class LocationManager(private val nativeLocationManager: NativeLocationMa
     }
 
     actual fun requestSingleUpdate(locationListener: LocationListener) {
-        nativeLocationManager.requestSingleUpdateWithLocationListener(locationListener)
+        nativeLocationManager.requestSingleUpdateWithLocationListener(locationListener.toNative())
     }
 
     actual fun unsubscribe(locationListener: LocationListener) {
-        nativeLocationManager.unsubscribeWithLocationListener(locationListener)
+        nativeLocationManager.unsubscribeWithLocationListener(locationListener.toNative())
     }
 
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/location/LocationStatus.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/location/LocationStatus.ios.kt
@@ -1,0 +1,20 @@
+package ru.sulgik.mapkit.location
+
+import YandexMapKit.YMKLocationStatus as NativeLocationStatus
+
+fun LocationStatus.toNative(): NativeLocationStatus {
+    return when (this) {
+        LocationStatus.NOT_AVAILABLE -> NativeLocationStatus.YMKLocationStatusNotAvailable
+        LocationStatus.AVAILABLE -> NativeLocationStatus.YMKLocationStatusAvailable
+        LocationStatus.RESET -> NativeLocationStatus.YMKLocationStatusReset
+    }
+}
+
+fun NativeLocationStatus.toCommon(): LocationStatus {
+    return when (this) {
+        NativeLocationStatus.YMKLocationStatusAvailable -> LocationStatus.AVAILABLE
+        NativeLocationStatus.YMKLocationStatusReset -> LocationStatus.RESET
+        NativeLocationStatus.YMKLocationStatusNotAvailable -> LocationStatus.NOT_AVAILABLE
+        else -> throw IllegalArgumentException("Unknown NativeLocationStatus ($this)")
+    }
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/location/LocationViewSource.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/location/LocationViewSource.ios.kt
@@ -1,0 +1,21 @@
+package ru.sulgik.mapkit.location
+
+import YandexMapKit.YMKLocationViewSource as NativeLocationViewSource
+import YandexMapKit.YMKLocationViewSourceFactory.Companion as NativeLocationViewSourceFactory
+
+actual class LocationViewSource(private val nativeLocationViewSource: NativeLocationViewSource) {
+
+    fun toNative(): NativeLocationViewSource {
+        return nativeLocationViewSource
+    }
+
+}
+
+fun NativeLocationViewSource.toCommon(): LocationViewSource {
+    return LocationViewSource(this)
+}
+
+actual fun LocationManager.toLocationViewSource(): LocationViewSource {
+    return NativeLocationViewSourceFactory.createLocationViewSourceWithLocationManager(this.toNative())
+        .toCommon()
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/logo/Alignment.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/logo/Alignment.ios.kt
@@ -1,0 +1,17 @@
+package ru.sulgik.mapkit.logo
+
+import YandexMapKit.YMKLogoAlignment as NativeAlignment
+
+fun Alignment.toNative(): NativeAlignment {
+    return NativeAlignment.alignmentWithHorizontalAlignment(
+        horizontalAlignment = horizontalAlignment.toNative(),
+        verticalAlignment = verticalAlignment.toNative()
+    )
+}
+
+fun NativeAlignment.toCommon(): Alignment {
+    return Alignment(
+        horizontalAlignment = horizontalAlignment.toCommon(),
+        verticalAlignment = verticalAlignment.toCommon(),
+    )
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/logo/HorizontalAlignment.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/logo/HorizontalAlignment.ios.kt
@@ -1,0 +1,20 @@
+package ru.sulgik.mapkit.logo
+
+import YandexMapKit.YMKLogoHorizontalAlignment as NativeHorizontalAlignment
+
+fun HorizontalAlignment.toNative(): NativeHorizontalAlignment {
+    return when (this) {
+        HorizontalAlignment.LEFT -> NativeHorizontalAlignment.YMKLogoHorizontalAlignmentLeft
+        HorizontalAlignment.CENTER -> NativeHorizontalAlignment.YMKLogoHorizontalAlignmentCenter
+        HorizontalAlignment.RIGHT -> NativeHorizontalAlignment.YMKLogoHorizontalAlignmentRight
+    }
+}
+
+fun NativeHorizontalAlignment.toCommon(): HorizontalAlignment {
+    return when (this) {
+        NativeHorizontalAlignment.YMKLogoHorizontalAlignmentLeft -> HorizontalAlignment.LEFT
+        NativeHorizontalAlignment.YMKLogoHorizontalAlignmentCenter -> HorizontalAlignment.CENTER
+        NativeHorizontalAlignment.YMKLogoHorizontalAlignmentRight -> HorizontalAlignment.RIGHT
+        else -> throw IllegalArgumentException("Unknown NativeTextStylePlacement ($this)")
+    }
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/logo/Logo.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/logo/Logo.ios.kt
@@ -1,0 +1,23 @@
+package ru.sulgik.mapkit.logo
+
+import YandexMapKit.YMKLogo as NativeLogo
+
+actual class Logo internal constructor(private val nativeLogo: NativeLogo){
+
+    fun toNative(): NativeLogo {
+        return nativeLogo
+    }
+
+    actual fun setAlignment(alignment: Alignment) {
+        nativeLogo.setAlignmentWithAlignment(alignment.toNative())
+    }
+
+    actual fun setPadding(padding: Padding) {
+        nativeLogo.setPaddingWithPadding(padding.toNative())
+    }
+
+}
+
+fun NativeLogo.toCommon(): Logo {
+    return Logo(this)
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/logo/Padding.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/logo/Padding.ios.kt
@@ -1,0 +1,17 @@
+package ru.sulgik.mapkit.logo
+
+import YandexMapKit.YMKLogoPadding as NativeLogoPadding
+
+fun Padding.toNative(): NativeLogoPadding {
+    return NativeLogoPadding.paddingWithHorizontalPadding(
+        horizontalPadding = horizontalPadding.toULong(),
+        verticalPadding = verticalPadding.toULong(),
+    )
+}
+
+fun NativeLogoPadding.toCommon(): Padding {
+    return Padding(
+        horizontalPadding = horizontalPadding.toInt(),
+        verticalPadding = verticalPadding.toInt(),
+    )
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/logo/VerticalAlignment.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/logo/VerticalAlignment.ios.kt
@@ -1,0 +1,19 @@
+package ru.sulgik.mapkit.logo
+
+import YandexMapKit.YMKLogoVerticalAlignment
+import YandexMapKit.YMKLogoVerticalAlignment as NativeVerticalAlignment
+
+fun VerticalAlignment.toNative(): NativeVerticalAlignment {
+    return when (this) {
+        VerticalAlignment.TOP -> NativeVerticalAlignment.YMKLogoVerticalAlignmentTop
+        VerticalAlignment.BOTTOM -> NativeVerticalAlignment.YMKLogoVerticalAlignmentBottom
+    }
+}
+
+fun NativeVerticalAlignment.toCommon(): VerticalAlignment {
+    return when (this) {
+        YMKLogoVerticalAlignment.YMKLogoVerticalAlignmentTop -> VerticalAlignment.TOP
+        YMKLogoVerticalAlignment.YMKLogoVerticalAlignmentBottom -> VerticalAlignment.BOTTOM
+        else -> throw IllegalArgumentException("Unknown NativeTextStylePlacement ($this)")
+    }
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/BaseMapObjectCollection.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/BaseMapObjectCollection.ios.kt
@@ -24,11 +24,11 @@ actual open class BaseMapObjectCollection internal constructor(private val nativ
     }
 
     actual fun addListener(collectionListener: MapObjectCollectionListener) {
-        nativeBaseMapObjectCollection.addListenerWithCollectionListener(collectionListener)
+        nativeBaseMapObjectCollection.addListenerWithCollectionListener(collectionListener.toNative())
     }
 
     actual fun removeListener(collectionListener: MapObjectCollectionListener) {
-        nativeBaseMapObjectCollection.removeListenerWithCollectionListener(collectionListener)
+        nativeBaseMapObjectCollection.removeListenerWithCollectionListener(collectionListener.toNative())
     }
 
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/BaseMapObjectCollection.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/BaseMapObjectCollection.ios.kt
@@ -1,6 +1,8 @@
 package ru.sulgik.mapkit.map
 
 import YandexMapKit.YMKBaseMapObjectCollection as NativeBaseMapObjectCollection
+import YandexMapKit.YMKClusterizedPlacemarkCollection as NativeClusterizedPlacemarkCollection1
+import YandexMapKit.YMKMapObjectCollection as NativeMapObjectCollection
 
 actual open class BaseMapObjectCollection internal constructor(private val nativeBaseMapObjectCollection: NativeBaseMapObjectCollection) :
     MapObject(nativeBaseMapObjectCollection) {
@@ -29,4 +31,13 @@ actual open class BaseMapObjectCollection internal constructor(private val nativ
         nativeBaseMapObjectCollection.removeListenerWithCollectionListener(collectionListener)
     }
 
+}
+
+
+fun NativeBaseMapObjectCollection.toCommon(): BaseMapObjectCollection {
+    return when (this) {
+        is NativeMapObjectCollection -> toCommon()
+        is NativeClusterizedPlacemarkCollection1 -> toCommon()
+        else -> BaseMapObjectCollection(this)
+    }
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/Callback.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/Callback.ios.kt
@@ -1,12 +1,19 @@
 package ru.sulgik.mapkit.map
 
-import YandexMapKit.YMKCallback
+import YandexMapKit.YMKCallback as NativeCallback
 
-actual abstract class Callback actual constructor() : YMKCallback {
+actual abstract class Callback actual constructor() {
+
+    private val nativeCallback = object : NativeCallback {
+        override fun invoke() {
+            onTaskFinished()
+        }
+    }
+
+    fun toNative(): NativeCallback {
+        return nativeCallback
+    }
 
     actual abstract fun onTaskFinished()
 
-    override fun invoke() {
-        onTaskFinished()
-    }
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/CameraCallback.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/CameraCallback.ios.kt
@@ -2,12 +2,18 @@ package ru.sulgik.mapkit.map
 
 import YandexMapKit.YMKMapCameraCallback as NativeCameraCallback
 
-actual abstract class CameraCallback : NativeCameraCallback {
+actual abstract class CameraCallback {
+
+    private val nativeCallback = object : NativeCameraCallback {
+        override fun invoke(p1: Boolean) {
+            onMoveFinished(p1)
+        }
+    }
+
+    fun toNative(): NativeCameraCallback {
+        return nativeCallback
+    }
 
     actual abstract fun onMoveFinished(completed: Boolean)
-
-    override fun invoke(p1: Boolean) {
-        onMoveFinished(p1)
-    }
 
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/CameraListener.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/CameraListener.ios.kt
@@ -6,27 +6,33 @@ import YandexMapKit.YMKCameraUpdateReason as NativeCameraUpdateReason
 import YandexMapKit.YMKMap as NativeMap
 import YandexMapKit.YMKMapCameraListenerProtocol as NativeCameraListener
 
-actual class CameraListener actual constructor(
-    private val onCameraPositionChanged: (
+actual abstract class CameraListener actual constructor() {
+
+    private val nativeListener = object : NativeCameraListener, NSObject() {
+        override fun onCameraPositionChangedWithMap(
+            map: NativeMap,
+            cameraPosition: NativeCameraPosition,
+            cameraUpdateReason: NativeCameraUpdateReason,
+            finished: Boolean,
+        ) {
+            onCameraPositionChanged(
+                map.toCommon(),
+                cameraPosition.toCommon(),
+                cameraUpdateReason.toCommon(),
+                finished
+            )
+        }
+    }
+
+    fun toNative(): NativeCameraListener {
+        return nativeListener
+    }
+
+
+    actual abstract fun onCameraPositionChanged(
         map: Map,
         cameraPosition: CameraPosition,
         cameraUpdateReason: CameraUpdateReason,
         finished: Boolean,
-    ) -> Unit,
-) : NativeCameraListener, NSObject() {
-
-    override fun onCameraPositionChangedWithMap(
-        map: NativeMap,
-        cameraPosition: NativeCameraPosition,
-        cameraUpdateReason: NativeCameraUpdateReason,
-        finished: Boolean,
-    ) {
-        onCameraPositionChanged.invoke(
-            map.toCommon(),
-            cameraPosition.toCommon(),
-            cameraUpdateReason.toCommon(),
-            finished
-        )
-    }
-
+    )
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/CameraListener.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/CameraListener.ios.kt
@@ -1,0 +1,32 @@
+package ru.sulgik.mapkit.map
+
+import platform.darwin.NSObject
+import YandexMapKit.YMKCameraPosition as NativeCameraPosition
+import YandexMapKit.YMKCameraUpdateReason as NativeCameraUpdateReason
+import YandexMapKit.YMKMap as NativeMap
+import YandexMapKit.YMKMapCameraListenerProtocol as NativeCameraListener
+
+actual class CameraListener actual constructor(
+    private val onCameraPositionChanged: (
+        map: Map,
+        cameraPosition: CameraPosition,
+        cameraUpdateReason: CameraUpdateReason,
+        finished: Boolean,
+    ) -> Unit,
+) : NativeCameraListener, NSObject() {
+
+    override fun onCameraPositionChangedWithMap(
+        map: NativeMap,
+        cameraPosition: NativeCameraPosition,
+        cameraUpdateReason: NativeCameraUpdateReason,
+        finished: Boolean,
+    ) {
+        onCameraPositionChanged.invoke(
+            map.toCommon(),
+            cameraPosition.toCommon(),
+            cameraUpdateReason.toCommon(),
+            finished
+        )
+    }
+
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/CameraPosition.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/CameraPosition.ios.kt
@@ -1,4 +1,3 @@
-package ru.sulgik.mapkit.map
 
 import ru.sulgik.mapkit.geometry.toCommon
 import ru.sulgik.mapkit.geometry.toNative

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/CameraPosition.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/CameraPosition.ios.kt
@@ -1,3 +1,4 @@
+package ru.sulgik.mapkit.map
 
 import ru.sulgik.mapkit.geometry.toCommon
 import ru.sulgik.mapkit.geometry.toNative

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/CameraUpdateReason.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/CameraUpdateReason.ios.kt
@@ -1,0 +1,19 @@
+package ru.sulgik.mapkit.map
+
+import YandexMapKit.YMKCameraUpdateReason as NativeCameraUpdateReason
+
+
+fun NativeCameraUpdateReason.toCommon(): CameraUpdateReason {
+    return when (this) {
+        NativeCameraUpdateReason.YMKCameraUpdateReasonGestures -> CameraUpdateReason.GESTURES
+        NativeCameraUpdateReason.YMKCameraUpdateReasonApplication -> CameraUpdateReason.APPLICATION
+        else -> throw IllegalArgumentException("Unknown NativeCameraUpdateReason ($this)")
+    }
+}
+
+fun CameraUpdateReason.toNative(): NativeCameraUpdateReason {
+    return when (this) {
+        CameraUpdateReason.GESTURES -> NativeCameraUpdateReason.YMKCameraUpdateReasonGestures
+        CameraUpdateReason.APPLICATION -> NativeCameraUpdateReason.YMKCameraUpdateReasonApplication
+    }
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/ClusterListener.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/ClusterListener.ios.kt
@@ -1,15 +1,24 @@
 package ru.sulgik.mapkit.map
 
-import YandexMapKit.YMKCluster
 import platform.darwin.NSObject
 import ru.sulgik.mapkit.geometry.Cluster
 import ru.sulgik.mapkit.geometry.toCommon
+import YandexMapKit.YMKCluster as NativeCluster
 import YandexMapKit.YMKClusterListenerProtocol as NativeClusterListener
 
-actual class ClusterListener actual constructor(private val onClusterAdded: (cluster: Cluster) -> Unit) :
-    NativeClusterListener, NSObject() {
+actual abstract class ClusterListener actual constructor() {
 
-    override fun onClusterAddedWithCluster(cluster: YMKCluster) {
-        onClusterAdded(cluster.toCommon())
+    private val nativeListener =
+        object : NativeClusterListener, NSObject() {
+            override fun onClusterAddedWithCluster(cluster: NativeCluster) {
+                onClusterAdded(cluster.toCommon())
+            }
+        }
+
+    fun toNative(): NativeClusterListener {
+        return nativeListener
     }
+
+    actual abstract fun onClusterAdded(cluster: Cluster)
+
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/ClusterTapListener.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/ClusterTapListener.ios.kt
@@ -6,12 +6,19 @@ import ru.sulgik.mapkit.geometry.Cluster
 import ru.sulgik.mapkit.geometry.toCommon
 import YandexMapKit.YMKClusterTapListenerProtocol as NativeClusterTapListener
 
-actual class ClusterTapListener actual constructor(val onClusterTap: (cluster: Cluster) -> Boolean) :
-    NativeClusterTapListener,
-    NSObject() {
+actual abstract class ClusterTapListener actual constructor() {
 
-    override fun onClusterTapWithCluster(cluster: YMKCluster): Boolean {
-        return onClusterTap(cluster.toCommon())
+    private val nativeListener = object : NativeClusterTapListener,
+        NSObject() {
+        override fun onClusterTapWithCluster(cluster: YMKCluster): Boolean {
+            return onClusterTap(cluster.toCommon())
+        }
     }
+
+    fun toNative(): NativeClusterTapListener {
+        return nativeListener
+    }
+
+    actual abstract fun onClusterTap(cluster: Cluster): Boolean
 
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/ClusterizedPlacemarkCollection.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/ClusterizedPlacemarkCollection.ios.kt
@@ -20,7 +20,7 @@ actual class ClusterizedPlacemarkCollection internal constructor(
 
     actual fun addPlacemark(placemarkCreatedCallback: PlacemarkCreatedCallback): PlacemarkMapObject {
         return nativeClusterizedPlacemarkCollection
-            .addPlacemarkWithPlacemarkCreatedCallback(placemarkCreatedCallback)
+            .addPlacemarkWithPlacemarkCreatedCallback(placemarkCreatedCallback.toNative())
             .toCommon()
     }
 

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/IconStyle.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/IconStyle.ios.kt
@@ -1,20 +1,17 @@
 package ru.sulgik.mapkit.map
 
 import YandexMapKit.YMKIconStyle
-import platform.Foundation.NSNumber
-import platform.Foundation.numberWithBool
-import platform.Foundation.numberWithFloat
-import platform.Foundation.numberWithInt
+import ru.sulgik.mapkit.toNSNumber
 import ru.sulgik.mapkit.toPointF
 
 fun IconStyle.toNative(): YMKIconStyle {
     return YMKIconStyle.iconStyleWithAnchor(
         anchor = null,
-        rotationType = rotationType?.ordinal?.let(NSNumber.Companion::numberWithInt),
-        zIndex = zIndex?.let(NSNumber.Companion::numberWithFloat),
-        flat = flat?.let(NSNumber.Companion::numberWithBool),
-        visible = isVisible?.let(NSNumber.Companion::numberWithBool),
-        scale = scale?.let(NSNumber.Companion::numberWithFloat),
+        rotationType = rotationType?.ordinal?.toNSNumber(),
+        zIndex = zIndex?.toNSNumber(),
+        flat = flat?.toNSNumber(),
+        visible = isVisible?.toNSNumber(),
+        scale = scale?.toNSNumber(),
         tappableArea = null,
     )
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/InputListener.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/InputListener.ios.kt
@@ -7,15 +7,28 @@ import YandexMapKit.YMKMap as NativeMap
 import YandexMapKit.YMKMapInputListenerProtocol as NativeInputListener
 import YandexMapKit.YMKPoint as NativePoint
 
-actual class InputListener actual constructor(
-    private val onMapTap: (map: Map, point: Point) -> Unit,
-    private val onMapLongTap: (map: Map, point: Point) -> Unit,
-) : NativeInputListener, NSObject() {
-    override fun onMapLongTapWithMap(map: NativeMap, point: NativePoint) {
-        onMapTap.invoke(map.toCommon(), point.toCommon())
+actual abstract class InputListener actual constructor() {
+    private val nativeListener = object : NativeInputListener, NSObject() {
+        override fun onMapLongTapWithMap(map: NativeMap, point: NativePoint) {
+            onMapTap(map.toCommon(), point.toCommon())
+        }
+
+        override fun onMapTapWithMap(map: NativeMap, point: NativePoint) {
+            onMapLongTap(map.toCommon(), point.toCommon())
+        }
     }
 
-    override fun onMapTapWithMap(map: NativeMap, point: NativePoint) {
-        onMapLongTap.invoke(map.toCommon(), point.toCommon())
+    fun toNative(): NativeInputListener {
+        return nativeListener
     }
+
+    actual abstract fun onMapTap(
+        map: Map,
+        point: Point,
+    )
+
+    actual abstract fun onMapLongTap(
+        map: Map,
+        point: Point,
+    )
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/InputListener.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/InputListener.ios.kt
@@ -1,0 +1,21 @@
+package ru.sulgik.mapkit.map
+
+import platform.darwin.NSObject
+import ru.sulgik.mapkit.geometry.Point
+import ru.sulgik.mapkit.geometry.toCommon
+import YandexMapKit.YMKMap as NativeMap
+import YandexMapKit.YMKMapInputListenerProtocol as NativeInputListener
+import YandexMapKit.YMKPoint as NativePoint
+
+actual class InputListener actual constructor(
+    private val onMapTap: (map: Map, point: Point) -> Unit,
+    private val onMapLongTap: (map: Map, point: Point) -> Unit,
+) : NativeInputListener, NSObject() {
+    override fun onMapLongTapWithMap(map: NativeMap, point: NativePoint) {
+        onMapTap.invoke(map.toCommon(), point.toCommon())
+    }
+
+    override fun onMapTapWithMap(map: NativeMap, point: NativePoint) {
+        onMapLongTap.invoke(map.toCommon(), point.toCommon())
+    }
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/Map.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/Map.ios.kt
@@ -85,6 +85,24 @@ actual class Map internal constructor(private val nativeMap: NativeMap) {
         }
 
     /**
+     * Enable/disable scroll gestures.
+     */
+    actual var isScrollGesturesEnabled: Boolean
+        get() = nativeMap.isScrollGesturesEnabled()
+        set(value) {
+            nativeMap.setScrollGesturesEnabled(value)
+        }
+
+    /**
+     * Enable/disable zoom gestures.
+     */
+    actual var isZoomGesturesEnabled: Boolean
+        get() = nativeMap.isZoomGesturesEnabled()
+        set(value) {
+            nativeMap.setZoomGesturesEnabled(value)
+        }
+
+    /**
      * Forces the map to be flat.
      *
      * true - All loaded tiles start showing the "flatten out" animation; all new tiles do not start 3D animation. false - All tiles start showing the "rise up" animation.

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/Map.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/Map.ios.kt
@@ -195,6 +195,29 @@ actual class Map internal constructor(private val nativeMap: NativeMap) {
         return nativeMap.logo.toCommon()
     }
 
+    /**
+     * The base map type.
+     */
+    actual var mapType: MapType
+        get() = nativeMap.mapType.toCommon()
+        set(value) {
+            nativeMap.mapType = value.toNative()
+        }
+
+    /**
+     * Adds input listeners.
+     */
+    actual fun addInputListener(inputListener: InputListener) {
+        nativeMap.addInputListenerWithInputListener(inputListener)
+    }
+
+    /**
+     * Removes input listeners.
+     */
+    actual fun removeInputListener(inputListener: InputListener) {
+        nativeMap.removeInputListenerWithInputListener(inputListener)
+    }
+
 }
 
 fun NativeMap.toCommon(): Map {

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/Map.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/Map.ios.kt
@@ -6,6 +6,8 @@ import ru.sulgik.mapkit.Animation
 import ru.sulgik.mapkit.ScreenRect
 import ru.sulgik.mapkit.geometry.Geometry
 import ru.sulgik.mapkit.geometry.toNative
+import ru.sulgik.mapkit.logo.Logo
+import ru.sulgik.mapkit.logo.toCommon
 import ru.sulgik.mapkit.toNative
 import YandexMapKit.YMKMap as NativeMap
 
@@ -170,6 +172,27 @@ actual class Map internal constructor(private val nativeMap: NativeMap) {
             animation.toNative(),
             cameraCallback
         )
+    }
+
+    /**
+     * Adds camera listeners.
+     */
+    actual fun addCameraListener(cameraListener: CameraListener) {
+        nativeMap.addCameraListenerWithCameraListener(cameraListener)
+    }
+
+    /**
+     * Removes camera listeners.
+     */
+    actual fun removeCameraListener(cameraListener: CameraListener) {
+        nativeMap.removeCameraListenerWithCameraListener(cameraListener)
+    }
+
+    /**
+     * Yandex logo object.
+     */
+    actual fun getLogo(): Logo {
+        return nativeMap.logo.toCommon()
     }
 
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/Map.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/Map.ios.kt
@@ -188,7 +188,7 @@ actual class Map internal constructor(private val nativeMap: NativeMap) {
         nativeMap.moveWithCameraPosition(
             cameraPosition.toNative(),
             animation.toNative(),
-            cameraCallback
+            cameraCallback?.toNative()
         )
     }
 
@@ -196,14 +196,14 @@ actual class Map internal constructor(private val nativeMap: NativeMap) {
      * Adds camera listeners.
      */
     actual fun addCameraListener(cameraListener: CameraListener) {
-        nativeMap.addCameraListenerWithCameraListener(cameraListener)
+        nativeMap.addCameraListenerWithCameraListener(cameraListener.toNative())
     }
 
     /**
      * Removes camera listeners.
      */
     actual fun removeCameraListener(cameraListener: CameraListener) {
-        nativeMap.removeCameraListenerWithCameraListener(cameraListener)
+        nativeMap.removeCameraListenerWithCameraListener(cameraListener.toNative())
     }
 
     /**
@@ -226,14 +226,14 @@ actual class Map internal constructor(private val nativeMap: NativeMap) {
      * Adds input listeners.
      */
     actual fun addInputListener(inputListener: InputListener) {
-        nativeMap.addInputListenerWithInputListener(inputListener)
+        nativeMap.addInputListenerWithInputListener(inputListener.toNative())
     }
 
     /**
      * Removes input listeners.
      */
     actual fun removeInputListener(inputListener: InputListener) {
-        nativeMap.removeInputListenerWithInputListener(inputListener)
+        nativeMap.removeInputListenerWithInputListener(inputListener.toNative())
     }
 
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/MapObject.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/MapObject.ios.kt
@@ -1,6 +1,11 @@
 package ru.sulgik.mapkit.map
 
 import YandexMapKit.YMKMapObject as NativeMapObject
+import YandexMapKit.YMKBaseMapObjectCollection as NativeBaseMapObjectCollection
+import YandexMapKit.YMKCircleMapObject as NativeCircleMapObject
+import YandexMapKit.YMKPlacemarkMapObject as NativePlacemarkMapObject
+import YandexMapKit.YMKPolygonMapObject as NativePolygonMapObject
+import YandexMapKit.YMKPolylineMapObject as NativePolylineMapObject
 
 actual open class MapObject internal constructor(private val nativeMapObject: NativeMapObject) {
 
@@ -47,5 +52,12 @@ actual open class MapObject internal constructor(private val nativeMapObject: Na
 }
 
 fun NativeMapObject.toCommon(): MapObject {
-    return MapObject(this)
+    return when (this) {
+        is NativeBaseMapObjectCollection -> toCommon()
+        is NativeCircleMapObject -> toCommon()
+        is NativePlacemarkMapObject -> toCommon()
+        is NativePolygonMapObject -> toCommon()
+        is NativePolylineMapObject -> toCommon()
+        else -> MapObject(this)
+    }
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/MapObject.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/MapObject.ios.kt
@@ -1,8 +1,8 @@
 package ru.sulgik.mapkit.map
 
-import YandexMapKit.YMKMapObject as NativeMapObject
 import YandexMapKit.YMKBaseMapObjectCollection as NativeBaseMapObjectCollection
 import YandexMapKit.YMKCircleMapObject as NativeCircleMapObject
+import YandexMapKit.YMKMapObject as NativeMapObject
 import YandexMapKit.YMKPlacemarkMapObject as NativePlacemarkMapObject
 import YandexMapKit.YMKPolygonMapObject as NativePolygonMapObject
 import YandexMapKit.YMKPolylineMapObject as NativePolylineMapObject
@@ -38,15 +38,15 @@ actual open class MapObject internal constructor(private val nativeMapObject: Na
         }
 
     actual fun addTapListener(tapListener: MapObjectTapListener) {
-        nativeMapObject.addTapListenerWithTapListener(tapListener)
+        nativeMapObject.addTapListenerWithTapListener(tapListener.toNative())
     }
 
     actual fun removeTapListener(tapListener: MapObjectTapListener) {
-        nativeMapObject.removeTapListenerWithTapListener(tapListener)
+        nativeMapObject.removeTapListenerWithTapListener(tapListener.toNative())
     }
 
     actual fun setDragListener(dragListener: MapObjectDragListener?) {
-        nativeMapObject.setDragListenerWithDragListener(dragListener)
+        nativeMapObject.setDragListenerWithDragListener(dragListener?.toNative())
     }
 
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/MapObjectCollection.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/MapObjectCollection.ios.kt
@@ -19,7 +19,7 @@ actual class MapObjectCollection internal constructor(private val nativeMapObjec
 
     actual fun addPlacemark(placemarkCreatedCallback: PlacemarkCreatedCallback): PlacemarkMapObject {
         return nativeMapObjectCollection.addPlacemarkWithPlacemarkCreatedCallback(
-            placemarkCreatedCallback
+            placemarkCreatedCallback.toNative()
         ).toCommon()
     }
 
@@ -41,7 +41,7 @@ actual class MapObjectCollection internal constructor(private val nativeMapObjec
 
     actual fun addClusterizedPlacemarkCollection(listener: ClusterListener): ClusterizedPlacemarkCollection {
         return nativeMapObjectCollection.addClusterizedPlacemarkCollectionWithClusterListener(
-            listener
+            listener.toNative()
         ).toCommon()
     }
 

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/MapObjectCollectionListener.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/MapObjectCollectionListener.ios.kt
@@ -1,20 +1,26 @@
 package ru.sulgik.mapkit.map
 
-import YandexMapKit.YMKMapObject
 import platform.darwin.NSObject
+import YandexMapKit.YMKMapObject as NativeMapObject
 import YandexMapKit.YMKMapObjectCollectionListenerProtocol as NativeMapObjectCollectionListener
 
-actual class MapObjectCollectionListener actual constructor(
-    val onMapObjectAdded: (mapObject: MapObject) -> Unit,
-    val onMapObjectRemoved: (mapObject: MapObject) -> Unit,
-) : NativeMapObjectCollectionListener,
-    NSObject() {
+actual abstract class MapObjectCollectionListener actual constructor() {
 
-    override fun onMapObjectRemovedWithMapObject(mapObject: YMKMapObject) {
-        onMapObjectRemoved(mapObject.toCommon())
+    private val nativeListener = object : NativeMapObjectCollectionListener, NSObject() {
+
+        override fun onMapObjectRemovedWithMapObject(mapObject: NativeMapObject) {
+            onMapObjectRemoved(mapObject.toCommon())
+        }
+
+        override fun onMapObjectAddedWithMapObject(mapObject: NativeMapObject) {
+            onMapObjectAdded(mapObject.toCommon())
+        }
     }
 
-    override fun onMapObjectAddedWithMapObject(mapObject: YMKMapObject) {
-        onMapObjectAdded(mapObject.toCommon())
+    fun toNative(): NativeMapObjectCollectionListener {
+        return nativeListener
     }
+
+    actual abstract fun onMapObjectAdded(mapObject: MapObject)
+    actual abstract fun onMapObjectRemoved(mapObject: MapObject)
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/MapObjectDragListener.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/MapObjectDragListener.ios.kt
@@ -1,27 +1,32 @@
 package ru.sulgik.mapkit.map
 
-import YandexMapKit.YMKMapObject
-import YandexMapKit.YMKMapObjectDragListenerProtocol
-import YandexMapKit.YMKPoint
 import platform.darwin.NSObject
 import ru.sulgik.mapkit.geometry.Point
 import ru.sulgik.mapkit.geometry.toCommon
+import YandexMapKit.YMKMapObject as NativeMapObject
+import YandexMapKit.YMKMapObjectDragListenerProtocol as NativeMapObjectDragListener
+import YandexMapKit.YMKPoint as NativePoint
 
-actual class MapObjectDragListener actual constructor(
-    private val onMapObjectDragStart: (mapObject: MapObject) -> Unit,
-    private val onMapObjectDrag: (mapObject: MapObject, point: Point) -> Unit,
-    private val onMapObjectDragEnd: (mapObject: MapObject) -> Unit,
-) : YMKMapObjectDragListenerProtocol, NSObject() {
+actual abstract class MapObjectDragListener actual constructor() {
+    private val nativeListener = object : NativeMapObjectDragListener, NSObject() {
+        override fun onMapObjectDragEndWithMapObject(mapObject: NativeMapObject) {
+            onMapObjectDragEnd(mapObject.toCommon())
+        }
 
-    override fun onMapObjectDragEndWithMapObject(mapObject: YMKMapObject) {
-        onMapObjectDragEnd(mapObject.toCommon())
+        override fun onMapObjectDragStartWithMapObject(mapObject: NativeMapObject) {
+            onMapObjectDragStart(mapObject.toCommon())
+        }
+
+        override fun onMapObjectDragWithMapObject(mapObject: NativeMapObject, point: NativePoint) {
+            onMapObjectDrag(mapObject.toCommon(), point.toCommon())
+        }
     }
 
-    override fun onMapObjectDragStartWithMapObject(mapObject: YMKMapObject) {
-        onMapObjectDragStart(mapObject.toCommon())
+    fun toNative(): NativeMapObjectDragListener {
+        return nativeListener
     }
 
-    override fun onMapObjectDragWithMapObject(mapObject: YMKMapObject, point: YMKPoint) {
-        onMapObjectDrag(mapObject.toCommon(), point.toCommon())
-    }
+    actual abstract fun onMapObjectDragStart(mapObject: MapObject)
+    actual abstract fun onMapObjectDrag(mapObject: MapObject, point: Point)
+    actual abstract fun onMapObjectDragEnd(mapObject: MapObject)
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/MapObjectTapListener.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/MapObjectTapListener.ios.kt
@@ -1,18 +1,28 @@
 package ru.sulgik.mapkit.map
 
-import YandexMapKit.YMKMapObject
-import YandexMapKit.YMKPoint
 import platform.darwin.NSObject
 import ru.sulgik.mapkit.geometry.Point
 import ru.sulgik.mapkit.geometry.toCommon
+import YandexMapKit.YMKMapObject as NativeMapObject
 import YandexMapKit.YMKMapObjectTapListenerProtocol as NativeMapObjectTapListener
+import YandexMapKit.YMKPoint as NativePoint
 
-actual class MapObjectTapListener actual constructor(
-    private val onMapObjectTap: (mapObject: MapObject, point: Point) -> Boolean,
-) : NativeMapObjectTapListener,
-    NSObject() {
-
-    override fun onMapObjectTapWithMapObject(mapObject: YMKMapObject, point: YMKPoint): Boolean {
-        return onMapObjectTap(mapObject.toCommon(), point.toCommon())
+actual abstract class MapObjectTapListener actual constructor() {
+    private val nativeListener = object : NativeMapObjectTapListener, NSObject() {
+        override fun onMapObjectTapWithMapObject(
+            mapObject: NativeMapObject,
+            point: NativePoint
+        ): Boolean {
+            return onMapObjectTap(mapObject.toCommon(), point.toCommon())
+        }
     }
+
+    fun toNative(): NativeMapObjectTapListener {
+        return nativeListener
+    }
+
+    actual abstract fun onMapObjectTap(
+        mapObject: MapObject,
+        point: Point
+    ): Boolean
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/MapType.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/MapType.ios.kt
@@ -1,0 +1,24 @@
+package ru.sulgik.mapkit.map
+
+import YandexMapKit.YMKMapType as NativeMapType
+
+fun MapType.toNative(): NativeMapType {
+    return when (this) {
+        MapType.NONE -> NativeMapType.YMKMapTypeNone
+        MapType.MAP -> NativeMapType.YMKMapTypeMap
+        MapType.SATELLITE -> NativeMapType.YMKMapTypeSatellite
+        MapType.HYBRID -> NativeMapType.YMKMapTypeHybrid
+        MapType.VECTOR_MAP -> NativeMapType.YMKMapTypeVectorMap
+    }
+}
+
+fun NativeMapType.toCommon(): MapType {
+    return when (this) {
+        NativeMapType.YMKMapTypeVectorMap -> MapType.VECTOR_MAP
+        NativeMapType.YMKMapTypeNone -> MapType.NONE
+        NativeMapType.YMKMapTypeSatellite -> MapType.SATELLITE
+        NativeMapType.YMKMapTypeMap -> MapType.MAP
+        NativeMapType.YMKMapTypeHybrid -> MapType.HYBRID
+        else -> throw IllegalArgumentException("Unknown NativeMapType ($this)")
+    }
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/MapWindow.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/MapWindow.kt
@@ -25,11 +25,11 @@ actual class MapWindow internal constructor(private val nativeMapWindow: NativeM
         get() = nativeMapWindow.map.toCommon()
 
     actual fun addSizeChangeListener(listener: SizeChangeListener) {
-        nativeMapWindow.addSizeChangedListenerWithSizeChangedListener(listener)
+        nativeMapWindow.addSizeChangedListenerWithSizeChangedListener(listener.toNative())
     }
 
     actual fun removeSizeChangeListener(listener: SizeChangeListener) {
-        nativeMapWindow.removeSizeChangedListenerWithSizeChangedListener(listener)
+        nativeMapWindow.removeSizeChangedListenerWithSizeChangedListener(listener.toNative())
     }
 
     actual var focusRect: ScreenRect?

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/PlacemarkCreatedCallback.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/PlacemarkCreatedCallback.ios.kt
@@ -1,16 +1,21 @@
 package ru.sulgik.mapkit.map
 
-import YandexMapKit.YMKPlacemarkMapObject
-import platform.darwin.NSObject
 import YandexMapKit.YMKPlacemarkCreatedCallback as NativePlacemarkCreatedCallback
+import YandexMapKit.YMKPlacemarkMapObject as NativePlacemarkMapObject
 
-actual class PlacemarkCreatedCallback actual constructor(
-    private val onPlacemarkCreated: (placemark: PlacemarkMapObject) -> Unit,
-) : NativePlacemarkCreatedCallback {
+actual abstract class PlacemarkCreatedCallback actual constructor() {
 
-    override fun invoke(p1: YMKPlacemarkMapObject?) {
-        if (p1 != null)
-            onPlacemarkCreated(p1.toCommon())
+    private val nativeCallback = object : NativePlacemarkCreatedCallback {
+        override fun invoke(p1: NativePlacemarkMapObject?) {
+            if (p1 != null) {
+                onPlacemarkCreated(p1.toCommon())
+            }
+        }
     }
 
+    fun toNative(): NativePlacemarkCreatedCallback {
+        return nativeCallback
+    }
+
+    actual abstract fun onPlacemarkCreated(placemark: PlacemarkMapObject)
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/PlacemarkMapObject.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/PlacemarkMapObject.ios.kt
@@ -42,7 +42,11 @@ actual class PlacemarkMapObject internal constructor(private val nativePlacemark
         style: IconStyle,
         onFinished: Callback?,
     ) {
-        nativePlacemarkMapObject.setIconWithImage(image.toNative(), style.toNative(), onFinished)
+        nativePlacemarkMapObject.setIconWithImage(
+            image.toNative(),
+            style.toNative(),
+            onFinished?.toNative(),
+        )
     }
 
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/PlacemarksStyler.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/PlacemarksStyler.ios.kt
@@ -6,7 +6,7 @@ import ru.sulgik.mapkit.PointF
 import ru.sulgik.mapkit.toNative
 import YandexMapKit.YMKPlacemarksStyler as NativePlacemarksStyler
 
-actual class PlacemarksStyler(private val nativePlacemarkStyle: NativePlacemarksStyler) {
+actual class PlacemarksStyler internal constructor(private val nativePlacemarkStyle: NativePlacemarksStyler) {
 
     fun toNative(): NativePlacemarksStyler {
         return nativePlacemarkStyle

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/SizeChangeListener.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/SizeChangeListener.ios.kt
@@ -1,21 +1,28 @@
 package ru.sulgik.mapkit.map
 
-import YandexMapKit.YMKMapWindow
 import platform.darwin.NSInteger
 import platform.darwin.NSObject
 import YandexMapKit.YMKMapSizeChangedListenerProtocol as NativeSizeChangeListener
+import YandexMapKit.YMKMapWindow as NativeMapWindow
 
-actual class SizeChangeListener actual constructor(
-    private val onMapWindowSizeChanged: (mapWindow: MapWindow, newWidth: Int, newHeight: Int) -> Unit,
-) :
-    NativeSizeChangeListener, NSObject() {
-
-    override fun onMapWindowSizeChangedWithMapWindow(
-        mapWindow: YMKMapWindow,
-        newWidth: NSInteger,
-        newHeight: NSInteger,
-    ) {
-        onMapWindowSizeChanged.invoke(mapWindow.toCommon(), newWidth.toInt(), newHeight.toInt())
+actual abstract class SizeChangeListener actual constructor() {
+    private val nativeListener = object : NativeSizeChangeListener, NSObject() {
+        override fun onMapWindowSizeChangedWithMapWindow(
+            mapWindow: NativeMapWindow,
+            newWidth: NSInteger,
+            newHeight: NSInteger,
+        ) {
+            onMapWindowSizeChanged(mapWindow.toCommon(), newWidth.toInt(), newHeight.toInt())
+        }
     }
 
+    fun toNative(): NativeSizeChangeListener {
+        return nativeListener
+    }
+
+    actual abstract fun onMapWindowSizeChanged(
+        mapWindow: MapWindow,
+        newWidth: Int,
+        newHeight: Int
+    )
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationAnchorChanged.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationAnchorChanged.ios.kt
@@ -1,0 +1,21 @@
+package ru.sulgik.mapkit.user_location
+
+import ru.sulgik.mapkit.layers.ObjectEvent
+import YandexMapKit.YMKUserLocationAnchorChanged as NativeUserLocationAnchorChanged
+
+actual class UserLocationAnchorChanged internal constructor(
+    private val nativeUserLocationAnchorChanged: NativeUserLocationAnchorChanged,
+) : ObjectEvent(nativeUserLocationAnchorChanged) {
+
+    override fun toNative(): NativeUserLocationAnchorChanged {
+        return nativeUserLocationAnchorChanged
+    }
+
+    actual val anchorType: UserLocationAnchorType
+        get() = nativeUserLocationAnchorChanged.anchorType.toCommon()
+
+}
+
+fun NativeUserLocationAnchorChanged.toCommon(): UserLocationAnchorChanged {
+    return UserLocationAnchorChanged(this)
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationAnchorType.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationAnchorType.ios.kt
@@ -1,0 +1,18 @@
+package ru.sulgik.mapkit.user_location
+
+import YandexMapKit.YMKUserLocationAnchorType as NativeUserLocationAnchorType
+
+fun UserLocationAnchorType.toNative(): NativeUserLocationAnchorType {
+    return when (this) {
+        UserLocationAnchorType.NORMAL -> NativeUserLocationAnchorType.YMKUserLocationAnchorTypeNormal
+        UserLocationAnchorType.COURSE -> NativeUserLocationAnchorType.YMKUserLocationAnchorTypeCourse
+    }
+}
+
+fun NativeUserLocationAnchorType.toCommon(): UserLocationAnchorType {
+    return when (this) {
+        NativeUserLocationAnchorType.YMKUserLocationAnchorTypeNormal -> UserLocationAnchorType.NORMAL
+        NativeUserLocationAnchorType.YMKUserLocationAnchorTypeCourse -> UserLocationAnchorType.COURSE
+        else -> throw IllegalArgumentException("Unknown NativeUserLocationAnchorType ($this)")
+    }
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationIconChanged.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationIconChanged.ios.kt
@@ -1,0 +1,21 @@
+package ru.sulgik.mapkit.user_location
+
+import ru.sulgik.mapkit.layers.ObjectEvent
+import YandexMapKit.YMKUserLocationIconChanged as NativeUserLocationIconChanged
+
+actual class UserLocationIconChanged internal constructor(
+    private val nativeUserLocationIconChanged: NativeUserLocationIconChanged,
+) : ObjectEvent(nativeUserLocationIconChanged) {
+
+    override fun toNative(): NativeUserLocationIconChanged {
+        return nativeUserLocationIconChanged
+    }
+
+    actual val iconType: UserLocationIconType
+        get() = nativeUserLocationIconChanged.iconType.toCommon()
+
+}
+
+fun NativeUserLocationIconChanged.toCommon(): UserLocationIconChanged {
+    return UserLocationIconChanged(this)
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationIconType.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationIconType.ios.kt
@@ -1,0 +1,19 @@
+package ru.sulgik.mapkit.user_location
+
+import YandexMapKit.YMKUserLocationIconType
+import YandexMapKit.YMKUserLocationIconType as NativeUserLocationIconType
+
+fun UserLocationIconType.toNative(): NativeUserLocationIconType {
+    return when (this) {
+        UserLocationIconType.ARROW -> NativeUserLocationIconType.YMKUserLocationIconTypeArrow
+        UserLocationIconType.PIN -> NativeUserLocationIconType.YMKUserLocationIconTypePin
+    }
+}
+
+fun NativeUserLocationIconType.toCommon(): UserLocationIconType {
+    return when (this) {
+        YMKUserLocationIconType.YMKUserLocationIconTypeArrow -> UserLocationIconType.ARROW
+        YMKUserLocationIconType.YMKUserLocationIconTypePin -> UserLocationIconType.PIN
+        else -> throw IllegalArgumentException("Unknown NativeTextStylePlacement ($this)")
+    }
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationLayer.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationLayer.ios.kt
@@ -94,7 +94,7 @@ actual class UserLocationLayer internal constructor(private val nativeUserLocati
      * while it is attached to a class.
      */
     actual fun setTapListener(tapListener: UserLocationTapListener?) {
-        nativeUserLocationLayer.setTapListenerWithTapListener(tapListener)
+        nativeUserLocationLayer.setTapListenerWithTapListener(tapListener?.toNative())
     }
 
     /**
@@ -105,7 +105,7 @@ actual class UserLocationLayer internal constructor(private val nativeUserLocati
      * while it is attached to a class.
      */
     actual fun setObjectListener(objectListener: UserLocationObjectListener?) {
-        nativeUserLocationLayer.setObjectListenerWithObjectListener(objectListener)
+        nativeUserLocationLayer.setObjectListenerWithObjectListener(objectListener?.toNative())
     }
 
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationLayer.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationLayer.ios.kt
@@ -1,0 +1,115 @@
+package ru.sulgik.mapkit.user_location
+
+import ru.sulgik.mapkit.PointF
+import ru.sulgik.mapkit.location.LocationViewSource
+import ru.sulgik.mapkit.map.CameraPosition
+import ru.sulgik.mapkit.map.toCommon
+import ru.sulgik.mapkit.toNative
+import YandexMapKit.YMKUserLocationLayer as NativeUserLocationLayer
+
+actual class UserLocationLayer internal constructor(private val nativeUserLocationLayer: NativeUserLocationLayer) {
+
+    fun toNative(): NativeUserLocationLayer {
+        return nativeUserLocationLayer
+    }
+
+    /**
+     * User location visibility.
+     */
+    actual var isVisible: Boolean
+        get() = nativeUserLocationLayer.isVisible()
+        set(value) {
+            nativeUserLocationLayer.setVisibleWithOn(value)
+        }
+
+    /**
+     * Heading mode.
+     */
+    actual var isHeadingEnabled: Boolean
+        get() = nativeUserLocationLayer.isHeadingEnabled()
+        set(value) {
+            nativeUserLocationLayer.setHeadingEnabled(value)
+        }
+
+    /**
+     * Returns true if anchor mode is set, and false otherwise.
+     */
+    actual val isAnchorEnabled: Boolean
+        get() = nativeUserLocationLayer.isAnchorEnabled()
+
+    /**
+     * Auto zoom.
+     */
+    actual var isAutoZoomEnabled: Boolean
+        get() = nativeUserLocationLayer.isAutoZoomEnabled()
+        set(value) {
+            nativeUserLocationLayer.setAutoZoomEnabled(value)
+        }
+
+    /**
+     * Calculates the camera position that projects the current location into view.
+     */
+    actual val cameraPosition: CameraPosition?
+        get() = nativeUserLocationLayer.cameraPosition()?.toCommon()
+
+    /**
+     * Sets the anchor to the specified position in pixels and enables Anchor mode.
+     */
+    actual fun setAnchor(
+        anchorNormal: PointF,
+        anchorCourse: PointF,
+    ) {
+        nativeUserLocationLayer.setAnchorWithAnchorNormal(
+            anchorNormal.toNative(),
+            anchorCourse.toNative()
+        )
+    }
+
+    /**
+     * Resets anchor mode.
+     */
+    actual fun resetAnchor() {
+        nativeUserLocationLayer.resetAnchor()
+    }
+
+    /**
+     * Sets/gets the data source.
+     */
+    actual fun setSource(source: LocationViewSource?) {
+        nativeUserLocationLayer.setSourceWithSource(source?.toNative())
+    }
+
+    /**
+     * Sets the data source with the global location manager
+     */
+    actual fun setDefaultSource() {
+        nativeUserLocationLayer.setDefaultSource()
+    }
+
+    /**
+     * Sets/resets the tap listener.
+     *
+     * The class does not retain the object in the 'tapListener' parameter.
+     * It is your responsibility to maintain a strong reference to the target object
+     * while it is attached to a class.
+     */
+    actual fun setTapListener(tapListener: UserLocationTapListener?) {
+        nativeUserLocationLayer.setTapListenerWithTapListener(tapListener)
+    }
+
+    /**
+     * Sets/resets the object listener.
+     *
+     * The class does not retain the object in the 'tapListener' parameter.
+     * It is your responsibility to maintain a strong reference to the target object
+     * while it is attached to a class.
+     */
+    actual fun setObjectListener(objectListener: UserLocationObjectListener?) {
+        nativeUserLocationLayer.setObjectListenerWithObjectListener(objectListener)
+    }
+
+}
+
+fun NativeUserLocationLayer.toCommon(): UserLocationLayer {
+    return UserLocationLayer(this)
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationObjectListener.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationObjectListener.ios.kt
@@ -7,21 +7,33 @@ import YandexMapKit.YMKObjectEvent as NativeObjectEvent
 import YandexMapKit.YMKUserLocationObjectListenerProtocol as NativeUserLocationObjectListener
 import YandexMapKit.YMKUserLocationView as NativeUserLocationView
 
-actual class UserLocationObjectListener actual constructor(
-    private val onObjectAdded: (view: UserLocationView) -> Unit,
-    private val onObjectRemoved: (view: UserLocationView) -> Unit,
-    private val onObjectUpdated: (view: UserLocationView, event: ObjectEvent) -> Unit,
-) : NativeUserLocationObjectListener, NSObject() {
+actual abstract class UserLocationObjectListener actual constructor() {
 
-    override fun onObjectAddedWithView(view: NativeUserLocationView) {
-        onObjectAdded.invoke(view.toCommon())
+    private val nativeListener = object : NativeUserLocationObjectListener, NSObject() {
+        override fun onObjectAddedWithView(view: NativeUserLocationView) {
+            onObjectAdded(view.toCommon())
+        }
+
+        override fun onObjectRemovedWithView(view: NativeUserLocationView) {
+            onObjectRemoved(view.toCommon())
+        }
+
+        override fun onObjectUpdatedWithView(
+            view: NativeUserLocationView,
+            event: NativeObjectEvent,
+        ) {
+            onObjectUpdated(view.toCommon(), event.toCommon())
+        }
     }
 
-    override fun onObjectRemovedWithView(view: NativeUserLocationView) {
-        onObjectRemoved.invoke(view.toCommon())
+    fun toNative(): NativeUserLocationObjectListener {
+        return nativeListener
     }
 
-    override fun onObjectUpdatedWithView(view: NativeUserLocationView, event: NativeObjectEvent) {
-        onObjectUpdated.invoke(view.toCommon(), event.toCommon())
-    }
+    actual abstract fun onObjectAdded(view: UserLocationView)
+    actual abstract fun onObjectRemoved(view: UserLocationView)
+    actual abstract fun onObjectUpdated(
+        view: UserLocationView,
+        event: ObjectEvent,
+    )
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationObjectListener.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationObjectListener.ios.kt
@@ -1,0 +1,27 @@
+package ru.sulgik.mapkit.user_location
+
+import platform.darwin.NSObject
+import ru.sulgik.mapkit.layers.ObjectEvent
+import ru.sulgik.mapkit.layers.toCommon
+import YandexMapKit.YMKObjectEvent as NativeObjectEvent
+import YandexMapKit.YMKUserLocationObjectListenerProtocol as NativeUserLocationObjectListener
+import YandexMapKit.YMKUserLocationView as NativeUserLocationView
+
+actual class UserLocationObjectListener actual constructor(
+    private val onObjectAdded: (view: UserLocationView) -> Unit,
+    private val onObjectRemoved: (view: UserLocationView) -> Unit,
+    private val onObjectUpdated: (view: UserLocationView, event: ObjectEvent) -> Unit,
+) : NativeUserLocationObjectListener, NSObject() {
+
+    override fun onObjectAddedWithView(view: NativeUserLocationView) {
+        onObjectAdded.invoke(view.toCommon())
+    }
+
+    override fun onObjectRemovedWithView(view: NativeUserLocationView) {
+        onObjectRemoved.invoke(view.toCommon())
+    }
+
+    override fun onObjectUpdatedWithView(view: NativeUserLocationView, event: NativeObjectEvent) {
+        onObjectUpdated.invoke(view.toCommon(), event.toCommon())
+    }
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationTapListener.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationTapListener.ios.kt
@@ -1,16 +1,23 @@
 package ru.sulgik.mapkit.user_location
 
-import YandexMapKit.YMKUserLocationTapListenerProtocol
 import platform.darwin.NSObject
 import ru.sulgik.mapkit.geometry.Point
 import ru.sulgik.mapkit.geometry.toCommon
 import YandexMapKit.YMKPoint as NativePoint
+import YandexMapKit.YMKUserLocationTapListenerProtocol as NativeUserLocationTapListener
 
-actual class UserLocationTapListener actual constructor(
-    private val onUserLocationObjectTap: (point: Point) -> Unit,
-) : YMKUserLocationTapListenerProtocol, NSObject() {
-    override fun onUserLocationObjectTapWithPoint(point: NativePoint) {
-        onUserLocationObjectTap.invoke(point.toCommon())
+actual abstract class UserLocationTapListener actual constructor() {
+
+    private val nativeListener = object : NativeUserLocationTapListener, NSObject() {
+        override fun onUserLocationObjectTapWithPoint(point: NativePoint) {
+            onUserLocationObjectTap(point.toCommon())
+        }
     }
+
+    fun toNative(): NativeUserLocationTapListener {
+        return nativeListener
+    }
+
+    actual abstract fun onUserLocationObjectTap(point: Point)
 
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationTapListener.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationTapListener.ios.kt
@@ -1,0 +1,16 @@
+package ru.sulgik.mapkit.user_location
+
+import YandexMapKit.YMKUserLocationTapListenerProtocol
+import platform.darwin.NSObject
+import ru.sulgik.mapkit.geometry.Point
+import ru.sulgik.mapkit.geometry.toCommon
+import YandexMapKit.YMKPoint as NativePoint
+
+actual class UserLocationTapListener actual constructor(
+    private val onUserLocationObjectTap: (point: Point) -> Unit,
+) : YMKUserLocationTapListenerProtocol, NSObject() {
+    override fun onUserLocationObjectTapWithPoint(point: NativePoint) {
+        onUserLocationObjectTap.invoke(point.toCommon())
+    }
+
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationView.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/user_location/UserLocationView.ios.kt
@@ -1,0 +1,25 @@
+package ru.sulgik.mapkit.user_location
+
+import ru.sulgik.mapkit.map.CircleMapObject
+import ru.sulgik.mapkit.map.PlacemarkMapObject
+import ru.sulgik.mapkit.map.toCommon
+import YandexMapKit.YMKUserLocationView as NativeUserLocationView
+
+actual class UserLocationView internal constructor(
+    private val nativeUserLocationView: NativeUserLocationView,
+) {
+    fun toNative(): NativeUserLocationView {
+        return nativeUserLocationView
+    }
+
+    actual val arrow: PlacemarkMapObject
+        get() = nativeUserLocationView.arrow.toCommon()
+    actual val pin: PlacemarkMapObject
+        get() = nativeUserLocationView.pin.toCommon()
+    actual val accuracyCircle: CircleMapObject
+        get() = nativeUserLocationView.accuracyCircle.toCommon()
+}
+
+fun NativeUserLocationView.toCommon(): UserLocationView {
+    return UserLocationView(this)
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/runtime/sensors/LocationActivityType.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/runtime/sensors/LocationActivityType.ios.kt
@@ -1,0 +1,23 @@
+package ru.sulgik.runtime.sensors
+
+import YandexMapKit.YRTLocationActivityType as NativeLocationActivityType
+
+
+fun LocationActivityType.toNative(): NativeLocationActivityType {
+    return when (this) {
+        LocationActivityType.AUTO_DETECT -> NativeLocationActivityType.YRTLocationActivityTypeAutoDetect
+        LocationActivityType.CAR -> NativeLocationActivityType.YRTLocationActivityTypeCar
+        LocationActivityType.PEDESTRIAN -> NativeLocationActivityType.YRTLocationActivityTypePedestrian
+        LocationActivityType.OTHER -> NativeLocationActivityType.YRTLocationActivityTypeOther
+    }
+}
+
+fun NativeLocationActivityType.toCommon(): LocationActivityType {
+    return when (this) {
+        NativeLocationActivityType.YRTLocationActivityTypeOther -> LocationActivityType.OTHER
+        NativeLocationActivityType.YRTLocationActivityTypeCar -> LocationActivityType.CAR
+        NativeLocationActivityType.YRTLocationActivityTypePedestrian -> LocationActivityType.PEDESTRIAN
+        NativeLocationActivityType.YRTLocationActivityTypeAutoDetect -> LocationActivityType.AUTO_DETECT
+        else -> throw IllegalArgumentException("Unknown NativeLocationActivityType ($this)")
+    }
+}


### PR DESCRIPTION
### Breaking changes

- All callbacks and listeners migrate to new API. Now it can be extended, but functional building with lambda is still available. Callbacks and listeners in native target does not implement original native callback or target. Use SomeListener.toNative() to convert it to original native listener, if you need.
- Add Location API, with user's location layer support. Check original yonder market docs as guide.
- Add CameraListener, Logo, MapType, InputListener Map.isScrollGesturesEnabled and Map.isZoomGesturesEnabled
- Change NativeMapObject.toCommon() and BaseMapObjectCollection.toCommon() logic. Now they produce same type as consume. For example, if we have object of type NativeMapObject (but real upcasted type is NativePlacemarkMapObject) if call toCommon, it produces object of type PlacemarkMapObject. (With previous behavior it would produce general MapObject with no way to upcast to PlacemarkMapObject)