### PR TITLE
fix crash on composition clear

### DIFF
--- a/yandex-mapkit-kmp-compose/src/commonMain/kotlin/ru/sulgik/mapkit/compose/MapObject.kt
+++ b/yandex-mapkit-kmp-compose/src/commonMain/kotlin/ru/sulgik/mapkit/compose/MapObject.kt
@@ -19,7 +19,7 @@ internal inline fun <reified T : MapObjectNode<R>, R : MapObject> MapObjectNode(
     zIndex: Float = 0.0f,
     noinline onTap: ((Point) -> Boolean)? = null,
     noinline factory: (applier: MapApplier) -> T,
-    update: @DisallowComposableCalls Updater<T>.() -> Unit
+    update: @DisallowComposableCalls Updater<T>.() -> Unit,
 ) {
     val mapApplier = currentComposer.applier as? MapApplier
         ?: error("Creating ${T::class} from not YandexMapComposable is not supported")
@@ -41,27 +41,14 @@ internal inline fun <reified T : MapObjectNode<R>, R : MapObject> MapObjectNode(
 
 internal abstract class MapObjectNode<T : MapObject>(
     val mapObject: T,
-    tapListener: ((point: Point) -> Boolean)?,
+    internal var tapListener: ((point: Point) -> Boolean)?,
 ) : MapNode {
-
-    internal var tapListener: ((point: Point) -> Boolean)? = tapListener
-        set(value) {
-            if (value == field) return
-            if (value == null) {
-                mapObject.removeTapListener(nativeTapListener)
-            } else if (field == null) {
-                mapObject.addTapListener(nativeTapListener)
-            }
-            field = value
-        }
 
     private val nativeTapListener =
         MapObjectTapListener { _, point -> tapListener?.invoke(point) ?: false }
 
     override fun onAttached() {
-        if (tapListener != null) {
-            mapObject.addTapListener(nativeTapListener)
-        }
+        mapObject.addTapListener(nativeTapListener)
     }
 
     override fun onRemoved() {
@@ -71,7 +58,6 @@ internal abstract class MapObjectNode<T : MapObject>(
 
     override fun onCleared() {
         tapListener = null
-        onRemoved()
     }
 
 }

--- a/yandex-mapkit-kmp-compose/src/commonMain/kotlin/ru/sulgik/mapkit/compose/composition/MapUpdater.kt
+++ b/yandex-mapkit-kmp-compose/src/commonMain/kotlin/ru/sulgik/mapkit/compose/composition/MapUpdater.kt
@@ -94,7 +94,6 @@ internal class MapPropertiesNode(
     }
 
     override fun onCleared() {
-        mapWindow.map.removeCameraListener(cameraListener)
         cameraPositionState.mapWindowOwner.setMapWindow(null)
     }
 

--- a/yandex-mapkit-kmp-compose/src/commonMain/kotlin/ru/sulgik/mapkit/compose/user_location/UserLocationUpdater.kt
+++ b/yandex-mapkit-kmp-compose/src/commonMain/kotlin/ru/sulgik/mapkit/compose/user_location/UserLocationUpdater.kt
@@ -157,7 +157,9 @@ internal class UserLocationNode(
 
     override fun onCleared() {
         super.onCleared()
-        onRemoved()
+        pin = null
+        arrow = null
+        accuracyCircle = null
     }
 
     override fun onRemoved() {


### PR DESCRIPTION
## Changes 

- onCleared in MapNode implementations does not call map specific api because it is already cleared as week reference

## Previous behavior 

RuntimeException on composition clearing 