### PR TITLE
Update dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,6 @@ org.gradle.configuration-cache=true
 
 #Kotlin
 kotlin.code.style=official
-kotlin.js.compiler=ir
 
 kotlin.apple.deprecated.allowUsingEmbedAndSignWithCocoaPodsDependencies=true
 
@@ -14,3 +13,5 @@ skipIosTarget=false
 #Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true
+kotlin.mpp.androidGradlePluginCompatibility.nowarn=true
+kotlin.apple.xcodeCompatibility.nowarn=true=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,14 +4,14 @@ android-minSdk = "24"
 android-targetSdk = "34"
 
 buildKonfig = "0.15.1"
-kotlin = "2.0.10"
-agp = "8.2.2"
+kotlin = "2.0.20"
+agp = "8.6.0"
 spotless = "7.0.0.BETA1"
-yandex-mapkit = "4.7.0-lite"
-compose-plugin = "1.6.11"
-androidx-activity = "1.9.1"
+yandex-mapkit = "4.8.0-lite"
+compose-plugin = "1.7.0-beta02"
+androidx-activity = "1.9.2"
 moko-resources = "0.24.1"
-lifecycle = "2.8.0"
+lifecycle = "2.8.2"
 datetime = "0.6.0"
 collections = "0.3.7"
 
@@ -24,7 +24,7 @@ yandex-mapkit = { module = "com.yandex.android:maps.mobile", version.ref = "yand
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 moko-resources = { module = "dev.icerock.moko:resources", version.ref = "moko-resources" }
 moko-resources-compose = { module = "dev.icerock.moko:resources-compose", version.ref = "moko-resources" }
-lifecycle-common = { module = "org.jetbrains.androidx.lifecycle:lifecycle-common", version.ref = "lifecycle" }
+lifecycle-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "datetime" }
 atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
 kotlinx-collections = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "collections" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jun 12 11:37:07 NOVT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sample/composeApp/src/commonMain/kotlin/ru/sulgik/mapkit/sample/ui/Buttons.kt
+++ b/sample/composeApp/src/commonMain/kotlin/ru/sulgik/mapkit/sample/ui/Buttons.kt
@@ -12,12 +12,12 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LocalAbsoluteTonalElevation
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.contentColorFor
+import androidx.compose.material3.ripple
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -103,7 +103,7 @@ fun CombinedSurface(
                     interactionSource = interactionSource,
                     onPress = onPress,
                     onPressRelease = onPressRelease,
-                    indication = rememberRipple(),
+                    indication = ripple(),
                 ),
             propagateMinConstraints = true
         ) {

--- a/sample/iosApp/Podfile.lock
+++ b/sample/iosApp/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - composeApp (1.0):
-    - YandexMapsMobile (= 4.7.0-lite)
-  - YandexMapsMobile (4.7.0-lite)
+    - YandexMapsMobile (= 4.8.0-lite)
+  - YandexMapsMobile (4.8.0-lite)
 
 DEPENDENCIES:
   - composeApp (from `../composeApp`)
@@ -15,8 +15,8 @@ EXTERNAL SOURCES:
     :path: "../composeApp"
 
 SPEC CHECKSUMS:
-  composeApp: 8ffce51f821289b3803ff3e97589a7b325518fad
-  YandexMapsMobile: 6ebee463d430506c6a12eebc57be02ac478e73c9
+  composeApp: 496d6946d4ede97540bc6a43f39a85462179ae8f
+  YandexMapsMobile: 115aa8c8e1d7d8f52a52d0559125f5c1c7e06165
 
 PODFILE CHECKSUM: 501c9565884acd2f13287e4df5f64b146b918298
 

--- a/yandex-mapkit-kmp-compose/build.gradle.kts
+++ b/yandex-mapkit-kmp-compose/build.gradle.kts
@@ -65,7 +65,8 @@ kotlin {
             implementation(compose.foundation)
             implementation(compose.ui)
             implementation(compose.components.resources)
-            implementation(libs.lifecycle.common)
+            implementation(libs.lifecycle.compose)
+            implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.8.2")
             implementation(libs.atomicfu)
             api(libs.kotlinx.collections)
         }

--- a/yandex-mapkit-kmp-compose/src/commonMain/kotlin/ru/sulgik/mapkit/compose/MapKit.kt
+++ b/yandex-mapkit-kmp-compose/src/commonMain/kotlin/ru/sulgik/mapkit/compose/MapKit.kt
@@ -2,8 +2,8 @@ package ru.sulgik.mapkit.compose
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import ru.sulgik.mapkit.MapKit
 import ru.sulgik.mapkit.compose.utils.LifecycleEffect
 

--- a/yandex-mapkit-kmp-compose/src/commonMain/kotlin/ru/sulgik/mapkit/compose/YandexMapController.kt
+++ b/yandex-mapkit-kmp-compose/src/commonMain/kotlin/ru/sulgik/mapkit/compose/YandexMapController.kt
@@ -2,8 +2,8 @@ package ru.sulgik.mapkit.compose
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import ru.sulgik.mapkit.compose.utils.LifecycleEffect
 import ru.sulgik.mapkit.map.MapWindow
 import ru.sulgik.mapkit.mapview.MapView

--- a/yandex-mapkit-kmp-compose/src/commonMain/kotlin/ru/sulgik/mapkit/compose/utils/Lifecycle.kt
+++ b/yandex-mapkit-kmp-compose/src/commonMain/kotlin/ru/sulgik/mapkit/compose/utils/Lifecycle.kt
@@ -3,7 +3,7 @@ package ru.sulgik.mapkit.compose.utils
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleObserver

--- a/yandex-mapkit-kmp-compose/src/iosMain/kotlin/ru/sulgik/mapkit/compose/NativeYandexMap.ios.kt
+++ b/yandex-mapkit-kmp-compose/src/iosMain/kotlin/ru/sulgik/mapkit/compose/NativeYandexMap.ios.kt
@@ -3,7 +3,7 @@ package ru.sulgik.mapkit.compose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.interop.UIKitView
+import androidx.compose.ui.viewinterop.UIKitView
 import ru.sulgik.mapkit.mapview.MapView
 import ru.sulgik.mapkit.mapview.toCommon
 import YandexMapKit.YMKMapView as NativeMapView

--- a/yandex-mapkit-kmp/build.gradle.kts
+++ b/yandex-mapkit-kmp/build.gradle.kts
@@ -78,6 +78,7 @@ kotlin {
     compilerOptions {
         freeCompilerArgs.add("-Xexplicit-api=strict")
         freeCompilerArgs.add("-Xexpect-actual-classes")
+        freeCompilerArgs.add("-Xconsistent-data-class-copy-visibility")
     }
 }
 

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/Color.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/Color.kt
@@ -1,9 +1,12 @@
 package ru.sulgik.mapkit
 
+import kotlin.jvm.JvmInline
+
 /**
  * Color in ARGB color model
  */
-public data class Color private constructor(internal val value: Int) {
+@JvmInline
+public value class Color private constructor(internal val value: Int) {
 
     public companion object {
         public fun fromArgb(argb: Int): Color {


### PR DESCRIPTION
## Cahnges 

- kotlin 2.0.10 to 2.0.20
- Compose multiplatform 1.6.11 to 1.7.0-beta02
- Yandex MapKit SDK 4.7.0-lite to 4.8.0-lite
- gradle to 8.9
- agp to 8.6.0
- Migrate from deprecated rememberRipple(), LocalLifecylceOwner, UIKitView
- Make Color value class