### PR TITLE
Update androidx

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,22 +1,22 @@
 [versions]
-android-compileSdk = "34"
+android-compileSdk = "35"
 android-minSdk = "26"
-android-targetSdk = "34"
+android-targetSdk = "35"
 
 buildKonfig = "0.15.1"
-kotlin = "2.0.21"
+kotlin = "2.1.10"
 agp = "8.6.1"
 yandex-mapkit = "4.11.0-lite"
-compose-plugin = "1.7.0"
-androidx-activity = "1.9.3"
-moko-resources = "0.24.3"
-lifecycle = "2.8.3"
+compose-plugin = "1.7.3"
+androidx-activity = "1.10.1"
+moko-resources = "0.24.5"
+lifecycle = "2.8.4"
 datetime = "0.6.1"
 collections = "0.3.8"
 
 publish = "0.30.0"
 
-atomicfu = "0.25.0"
+atomicfu = "0.27.0"
 dokka = "1.9.20"
 
 [libraries]

--- a/yandex-mapkit-kmp-compose/src/commonMain/kotlin/ru/sulgik/mapkit/compose/Polyline.kt
+++ b/yandex-mapkit-kmp-compose/src/commonMain/kotlin/ru/sulgik/mapkit/compose/Polyline.kt
@@ -180,15 +180,15 @@ internal fun PolylineImpl(
         onTap = onTap,
         factory = {
             val mapObject = collection.addPolyline(state.geometry)
-            mapObject.strokeWidth = strokeWidth
-            mapObject.gradientLength = gradientLength
-            mapObject.outlineWidth = outlineWidth
-            mapObject.outlineColor = outlineColor.toMapkitColor()
-            mapObject.isInnerOutlineEnabled = innerOutlineEnabled
-            mapObject.turnRadius = turnRadius
-            mapObject.dashLength = dashLength
-            mapObject.gapLength = gapLength
-            mapObject.dashOffset = dashOffset
+            mapObject.style.strokeWidth = strokeWidth
+            mapObject.style.gradientLength = gradientLength
+            mapObject.style.outlineWidth = outlineWidth
+            mapObject.style.outlineColor = outlineColor.toMapkitColor()
+            mapObject.style.innerOutlineEnabled = innerOutlineEnabled
+            mapObject.style.turnRadius = turnRadius
+            mapObject.style.dashLength = dashLength
+            mapObject.style.gapLength = gapLength
+            mapObject.style.dashOffset = dashOffset
             mapObject.setStrokeColor(strokeColor.toMapkitColor())
             PolylineNode(
                 mapObject = mapObject,

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/LineStyle.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/LineStyle.android.kt
@@ -1,35 +1,95 @@
 package ru.sulgik.mapkit.map
 
+import ru.sulgik.mapkit.Color
 import ru.sulgik.mapkit.toArgb
 import ru.sulgik.mapkit.toColor
 import com.yandex.mapkit.map.LineStyle as NativeLineStyle
 
-public fun LineStyle.toNative(): NativeLineStyle {
-    return NativeLineStyle(
-        strokeWidth,
-        gradientLength,
-        outlineColor.toArgb(),
-        outlineWidth,
-        innerOutlineEnabled,
-        turnRadius,
-        arcApproximationStep,
-        dashLength,
-        gapLength,
-        dashOffset
+public actual class LineStyle internal constructor(
+    private val nativeLineStyle: NativeLineStyle,
+) {
+    public actual var strokeWidth: Float
+        get() = nativeLineStyle.strokeWidth
+        set(value) {
+            nativeLineStyle.strokeWidth = value
+        }
+    public actual var gradientLength: Float
+        get() = nativeLineStyle.gradientLength
+        set(value) {
+            nativeLineStyle.gradientLength = value
+        }
+    public actual var outlineColor: Color
+        get() = nativeLineStyle.outlineColor.toColor()
+        set(value) {
+            nativeLineStyle.outlineColor = value.toArgb()
+        }
+    public actual var outlineWidth: Float
+        get() = nativeLineStyle.outlineWidth
+        set(value) {
+            nativeLineStyle.outlineWidth = value
+        }
+    public actual var innerOutlineEnabled: Boolean
+        get() = nativeLineStyle.innerOutlineEnabled
+        set(value) {
+            nativeLineStyle.innerOutlineEnabled = value
+        }
+    public actual var turnRadius: Float
+        get() = nativeLineStyle.turnRadius
+        set(value) {
+            nativeLineStyle.turnRadius = value
+        }
+    public actual var arcApproximationStep: Float
+        get() = nativeLineStyle.arcApproximationStep
+        set(value) {
+            nativeLineStyle.arcApproximationStep = value
+        }
+    public actual var dashLength: Float
+        get() = nativeLineStyle.dashLength
+        set(value) {
+            nativeLineStyle.dashLength = value
+        }
+    public actual var gapLength: Float
+        get() = nativeLineStyle.gapLength
+        set(value) {
+            nativeLineStyle.gapLength = value
+        }
+    public actual var dashOffset: Float
+        get() = nativeLineStyle.dashOffset
+        set(value) {
+            nativeLineStyle.dashOffset = value
+        }
+
+    public actual constructor(
+        strokeWidth: Float,
+        gradientLength: Float,
+        outlineColor: Color,
+        outlineWidth: Float,
+        innerOutlineEnabled: Boolean,
+        turnRadius: Float,
+        arcApproximationStep: Float,
+        dashLength: Float,
+        gapLength: Float,
+        dashOffset: Float
+    ) : this(
+        NativeLineStyle(
+            strokeWidth,
+            gradientLength,
+            outlineColor.toArgb(),
+            outlineWidth,
+            innerOutlineEnabled,
+            turnRadius,
+            arcApproximationStep,
+            dashLength,
+            gapLength,
+            dashOffset
+        )
     )
+
+    public fun toNative(): NativeLineStyle {
+        return nativeLineStyle
+    }
 }
 
 public fun NativeLineStyle.toCommon(): LineStyle {
-    return LineStyle(
-        strokeWidth = strokeWidth,
-        gradientLength = gradientLength,
-        outlineColor = outlineColor.toColor(),
-        outlineWidth = outlineWidth,
-        innerOutlineEnabled = innerOutlineEnabled,
-        turnRadius = turnRadius,
-        arcApproximationStep = arcApproximationStep,
-        dashLength = dashLength,
-        gapLength = gapLength,
-        dashOffset = dashOffset,
-    )
+    return LineStyle(this)
 }

--- a/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/LineStyle.kt
+++ b/yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/LineStyle.kt
@@ -2,15 +2,27 @@ package ru.sulgik.mapkit.map
 
 import ru.sulgik.mapkit.Color
 
-public data class LineStyle(
-    val strokeWidth: Float = 5.0F,
-    val gradientLength: Float = 0.0F,
-    val outlineColor: Color = Color.fromArgb(0),
-    val outlineWidth: Float = 0.0F,
-    val innerOutlineEnabled: Boolean = false,
-    val turnRadius: Float = 10.0F,
-    val arcApproximationStep: Float = 12.0F,
-    val dashLength: Float = 0.0F,
-    val gapLength: Float = 0.0F,
-    val dashOffset: Float = 0.0F
-)
+public expect class LineStyle public constructor(
+    strokeWidth: Float = 5.0F,
+    gradientLength: Float = 0.0F,
+    outlineColor: Color = Color.fromArgb(0),
+    outlineWidth: Float = 0.0F,
+    innerOutlineEnabled: Boolean = false,
+    turnRadius: Float = 10.0F,
+    arcApproximationStep: Float = 12.0F,
+    dashLength: Float = 0.0F,
+    gapLength: Float = 0.0F,
+    dashOffset: Float = 0.0F
+) {
+    public var strokeWidth: Float
+    public var gradientLength: Float
+    public var outlineColor: Color
+    public var outlineWidth: Float
+    public var innerOutlineEnabled: Boolean
+    public var turnRadius: Float
+    public var arcApproximationStep: Float
+    public var dashLength: Float
+    public var gapLength: Float
+    public var dashOffset: Float
+
+}

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/LineStyle.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/LineStyle.ios.kt
@@ -1,35 +1,93 @@
 package ru.sulgik.mapkit.map
 
+import ru.sulgik.mapkit.Color
 import ru.sulgik.mapkit.toCommon
 import ru.sulgik.mapkit.toNative
 import YandexMapKit.YMKLineStyle as NativeLineStyle
 
-public fun LineStyle.toNative(): NativeLineStyle {
-    return NativeLineStyle.lineStyleWithStrokeWidth(
-        strokeWidth,
-        gradientLength,
-        outlineColor.toNative(),
-        outlineWidth,
-        innerOutlineEnabled,
-        turnRadius,
-        arcApproximationStep,
-        dashLength,
-        gapLength,
-        dashOffset
+public actual class LineStyle internal constructor(private val nativeLineStyle: NativeLineStyle) {
+    public actual var strokeWidth: Float
+        get() = nativeLineStyle.strokeWidth
+        set(value) {
+            nativeLineStyle.setStrokeWidth(value)
+        }
+    public actual var gradientLength: Float
+        get() = nativeLineStyle.gradientLength
+        set(value) {
+            nativeLineStyle.setGradientLength(value)
+        }
+    public actual var outlineColor: Color
+        get() = nativeLineStyle.outlineColor.toCommon()
+        set(value) {
+            nativeLineStyle.setOutlineColor(value.toNative())
+        }
+    public actual var outlineWidth: Float
+        get() = nativeLineStyle.outlineWidth
+        set(value) {
+            nativeLineStyle.setOutlineWidth(value)
+        }
+    public actual var innerOutlineEnabled: Boolean
+        get() = nativeLineStyle.innerOutlineEnabled
+        set(value) {
+            nativeLineStyle.setInnerOutlineEnabled(value)
+        }
+    public actual var turnRadius: Float
+        get() = nativeLineStyle.turnRadius
+        set(value) {
+            nativeLineStyle.setTurnRadius(value)
+        }
+    public actual var arcApproximationStep: Float
+        get() = nativeLineStyle.arcApproximationStep
+        set(value) {
+            nativeLineStyle.setArcApproximationStep(value)
+        }
+    public actual var dashLength: Float
+        get() = nativeLineStyle.dashLength
+        set(value) {
+            nativeLineStyle.setDashLength(value)
+        }
+    public actual var gapLength: Float
+        get() = nativeLineStyle.gapLength
+        set(value) {
+            nativeLineStyle.setGapLength(value)
+        }
+    public actual var dashOffset: Float
+        get() = nativeLineStyle.dashOffset
+        set(value) {
+            nativeLineStyle.setDashOffset(value)
+        }
+
+    public actual constructor(
+        strokeWidth: Float,
+        gradientLength: Float,
+        outlineColor: Color,
+        outlineWidth: Float,
+        innerOutlineEnabled: Boolean,
+        turnRadius: Float,
+        arcApproximationStep: Float,
+        dashLength: Float,
+        gapLength: Float,
+        dashOffset: Float
+    ) : this(
+        NativeLineStyle.lineStyleWithStrokeWidth(
+            strokeWidth = strokeWidth,
+            gradientLength = gradientLength,
+            outlineColor = outlineColor.toNative(),
+            outlineWidth = outlineWidth,
+            innerOutlineEnabled = innerOutlineEnabled,
+            turnRadius = turnRadius,
+            arcApproximationStep = arcApproximationStep,
+            dashLength = dashLength,
+            gapLength = gapLength,
+            dashOffset = dashOffset,
+        )
     )
+
+    public fun toNative(): NativeLineStyle {
+        return nativeLineStyle
+    }
 }
 
 public fun NativeLineStyle.toCommon(): LineStyle {
-    return LineStyle(
-        strokeWidth = strokeWidth,
-        gradientLength = gradientLength,
-        outlineColor = outlineColor.toCommon(),
-        outlineWidth = outlineWidth,
-        innerOutlineEnabled = innerOutlineEnabled,
-        turnRadius = turnRadius,
-        arcApproximationStep = arcApproximationStep,
-        dashLength = dashLength,
-        gapLength = gapLength,
-        dashOffset = dashOffset,
-    )
+    return LineStyle(this)
 }


### PR DESCRIPTION
This pull request includes several updates to dependencies and significant refactoring of the `LineStyle` class to improve its implementation across different platforms. The most important changes include updating SDK versions and dependencies, refactoring the `LineStyle` class to use platform-specific implementations, and modifying the `PolylineImpl` to use the new `LineStyle` class.

Dependency Updates:
* Updated `android-compileSdk` and `android-targetSdk` to version 35, and updated several dependencies including `kotlin`, `compose-plugin`, `androidx-activity`, `moko-resources`, `lifecycle`, and `atomicfu` to their latest versions (`gradle/libs.versions.toml`).

Refactoring `LineStyle` Class:
* Changed `LineStyle` to an `expect` class with platform-specific actual implementations for Android and iOS, allowing for more flexible and maintainable code (`yandex-mapkit-kmp/src/commonMain/kotlin/ru/sulgik/mapkit/map/LineStyle.kt`).
* Implemented the `LineStyle` class for Android, encapsulating the native `NativeLineStyle` and providing properties with getters and setters (`yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/map/LineStyle.android.kt`). [[1]](diffhunk://#diff-76c16f10533d1deb9cbfbf16ad0776fb2e6fcf48890e16955000c798b6814917R3-R74) [[2]](diffhunk://#diff-76c16f10533d1deb9cbfbf16ad0776fb2e6fcf48890e16955000c798b6814917R86-R94)
* Implemented the `LineStyle` class for iOS, encapsulating the native `NativeLineStyle` and providing properties with getters and setters (`yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/map/LineStyle.ios.kt`). [[1]](diffhunk://#diff-74d7cb3993711eddf24287646cc0bb11cf5bc59d879f151f844eff5abb209828R3-R75) [[2]](diffhunk://#diff-74d7cb3993711eddf24287646cc0bb11cf5bc59d879f151f844eff5abb209828R84-R92)

Modifying `PolylineImpl`:
* Updated `PolylineImpl` to use the new `LineStyle` class, ensuring that the style properties are set correctly on the `mapObject` (`yandex-mapkit-kmp-compose/src/commonMain/kotlin/ru/sulgik/mapkit/compose/Polyline.kt`).