### PR TITLE
Add CLAUDE.md and Claude Code skills for project architecture and conventions

### DIFF
--- a/.claude/skills/ymk-architecture/SKILL.md
+++ b/.claude/skills/ymk-architecture/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: ymk-architecture
+description: >-
+  Map of the yandex-mapkit-kmp repository — module layout, package structure, source-set and
+  file naming, and the house Kotlin style (explicit API strict, toNative()/toCommon() converter
+  vocabulary, Native* import aliases, KDoc policy, no inline comments). Use this whenever you
+  touch Kotlin in this repository and need to know where code belongs, how to name a file or
+  package, or what the project conventions are — including questions phrased as "как устроен
+  проект", "где лежит X", "куда положить новый тип", "какие правила именования", "почему тут
+  toCommon". Read it before writing the first line of code here; it also points to the
+  task-specific skills for the wrapper and Compose modules.
+---
+
+# yandex-mapkit-kmp architecture
+
+This repository is a **Kotlin-first multiplatform wrapper over the official Yandex MapKit SDK**
+(Android `com.yandex.mapkit`, iOS `YandexMapKit`/`YMK*` via CocoaPods). Everything in the codebase
+follows from one goal: *a caller writing common Kotlin should see an API that reads exactly like the
+original MapKit, but is platform-independent, null-safe and Kotlin-idiomatic.*
+
+Knowing that goal explains most conventions below — when a rule looks arbitrary, ask "does this keep
+the common API looking like MapKit while hiding the native type?" and the answer is usually yes.
+
+## Modules
+
+| Module | Package root | Android namespace | Purpose |
+|---|---|---|---|
+| `yandex-mapkit-kmp` | `ru.sulgik.mapkit` | `ru.sulgik.mapkit` | The wrapper itself: every MapKit type usable from common code |
+| `yandex-mapkit-kmp-compose` | `ru.sulgik.mapkit.compose` | `ru.sulgik.mapkit.compose` | Compose Multiplatform map rendering, states and node composition |
+| `yandex-mapkit-kmp-moko` | `ru.sulgik.mapkit.moko` | — | `moko-resources` images as `ImageProvider` |
+| `yandex-mapkit-kmp-moko-compose` | `ru.sulgik.mapkit.moko.compose` | — | `rememberMOKOImageLoader()` for the Compose case |
+| `sample:composeApp` | — | — | Sample app, needs `MAPKIT_API_KEY` in `local.properties` |
+
+Publication coordinates are `ru.sulgik.mapkit:<module>`, version comes from the `library_version`
+property in [gradle.properties](gradle.properties). MapKit's own version lives in
+[gradle/libs.versions.toml](gradle/libs.versions.toml) as `yandex-mapkit`.
+
+`yandex-mapkit-kmp` and `yandex-mapkit-kmp-compose` compile with `-Xexplicit-api=strict`; the two
+moko modules do not, which is why their sources have no `public` modifiers. Match the module you are
+editing rather than "fixing" the moko modules.
+
+## Package layout mirrors MapKit
+
+Packages are the MapKit packages with `com.yandex.mapkit` swapped for `ru.sulgik.mapkit`. That is a
+documented migration promise (see [docs/wrapper/overview.md](docs/wrapper/overview.md)): users change
+the import prefix and their map logic keeps compiling.
+
+```
+ru.sulgik.mapkit            MapKit, Animation, Color, PointF, ScreenPoint, ScreenRect
+ru.sulgik.mapkit.geometry   Point, Latitude, Longitude, Polyline, Polygon, BoundingBox, Cluster, …
+ru.sulgik.mapkit.map        Map, MapWindow, CameraPosition, MapObject*, listeners, styles
+ru.sulgik.mapkit.mapview    MapView
+ru.sulgik.mapkit.location   LocationManager, Location, SubscriptionSettings, …
+ru.sulgik.mapkit.logo       Logo, LogoAlignment, LogoPadding, …
+ru.sulgik.mapkit.indoor     IndoorPlan, IndoorLevel, IndoorStateListener
+ru.sulgik.mapkit.layers     ObjectEvent
+ru.sulgik.mapkit.user_location  UserLocationLayer, UserLocationView, …
+```
+
+`user_location` keeps MapKit's snake_case name on purpose — do not "correct" it to `userlocation`.
+
+Compose adds `ru.sulgik.mapkit.compose` plus `compose.composition` (applier/updater internals),
+`compose.user_location` and `compose.utils` (colors, lifecycle helpers).
+
+New type in a package MapKit already has? Use that package. New type with no MapKit counterpart
+(e.g. `AndroidImageProvider`)? Put it in the package of the type it serves.
+
+## Source sets and file naming
+
+One public type per file, file named after the type:
+
+```
+commonMain/kotlin/ru/sulgik/mapkit/geometry/Point.kt          common declaration
+androidMain/kotlin/ru/sulgik/mapkit/geometry/Point.android.kt  actual + converters
+iosMain/kotlin/ru/sulgik/mapkit/geometry/Point.ios.kt          actual + converters
+```
+
+The `.android.kt` / `.ios.kt` suffix is mandatory for platform files that complete a common
+declaration. Platform-only types that have no common counterpart drop the suffix, because there is
+nothing to disambiguate: `map/AndroidImageProvider.kt`, `map/UIImageImageProvider.kt`.
+
+A handful of existing files break this (`geometry/PolylinePosition.andoird.kt`, `location/
+SubscriptionSettings.android.kt` sitting in **iosMain**, `map/MapWindow.kt` in iosMain, `logo/
+Alignment.android.kt` holding `LogoAlignment` converters). They are historical typos — never copy
+them, and prefer the correct name when you touch such a file for other reasons.
+
+## The converter vocabulary: exactly two names
+
+Every crossing of the common/native boundary is spelled `toNative()` or `toCommon()`. There are ~72
+`toNative` and ~133 `toCommon` declarations and no synonyms — no `asNative`, no `convert`, no
+`fromNative`. Keeping this vocabulary is what makes the wrapper predictable to read.
+
+```kotlin
+public fun Point.toNative(): NativePoint
+public fun NativePoint.toCommon(): Point
+```
+
+Two rules that follow from it:
+
+- **Converters never live in `commonMain`.** `commonMain` has no idea a native type exists. If you
+  are tempted to declare `toNative()` in an `expect` class, stop — the wrapper classes declare it in
+  each `actual` only, with the platform return type.
+- **The native counterpart of the file's common type is imported under a `Native<CommonName>`
+  alias**, and alias imports sit at the bottom of the import block:
+
+```kotlin
+import ru.sulgik.mapkit.geometry.toCommon
+import ru.sulgik.mapkit.geometry.toNative
+import YandexMapKit.YMKCameraPosition as NativeCameraPosition
+```
+
+The alias is named after the **common** type (`NativeCameraPosition`, not `NativeYMKCameraPosition`),
+so the same code shape reads identically on both platforms. Helper native types used only for a cast
+or a protocol signature may keep their own name (`YMKPoint` in `LinearRing.ios.kt`). A few files skip
+the alias for their main type too (`IconStyle.ios.kt`, `MapObjectVisitor.ios.kt`) — that is drift,
+not a second convention.
+
+Domain-level conversions that are not the native boundary use their own verbs and are fine:
+`Point.toGeometry()`, `Bitmap.toImageProvider()`, `ComposeColor.toMapkitColor()`, `Color.toArgb()`.
+
+## Which pattern for a new type
+
+Three shapes cover the whole wrapper. Pick by asking *"does this thing hold native state?"*
+
+1. **Value type** — immutable data carried across the boundary (`Point`, `CameraPosition`,
+   `IconStyle`, `Animation`, `Location`). A plain `data class` (or `@JvmInline value class` for a
+   single scalar) in `commonMain`, converters in each platform set.
+2. **Handle type** — a live native object the caller drives (`Map`, `MapWindow`,
+   `PlacemarkMapObject`, `LocationManager`). `expect class` in common, `actual class X internal
+   constructor(private val nativeX: NativeX)` per platform, with `toNative()` as a member and
+   `NativeX.toCommon()` as a top-level function.
+3. **Listener / callback** — `expect abstract class X()` plus an inline `X(crossinline …)` factory
+   in common, and an `actual` holding a single `nativeListener` field.
+
+Full templates with the reasoning behind each line: **use the `ymk-wrapper-api` skill**.
+Adding a Compose composable, state or map node: **use the `ymk-compose-api` skill**.
+Checking existing or generated code against these rules: **use the `ymk-conventions-review` skill**.
+
+## Kotlin style in this repo
+
+Read [references/kotlin-style.md](references/kotlin-style.md) for the full list. The essentials:
+
+- Explicit `public` and explicit return types on every public declaration (explicit API strict).
+- Function bodies use a block with `return`, not expression bodies — the codebase is uniform on this.
+- KDoc on public API, copied from the official MapKit docs, and repeated on the `actual` members so
+  both IDE navigation targets show it. `-Xexport-kdoc` forwards it into the generated ObjC headers.
+- **No explanatory comments in code.** The wrapper is intentionally comment-free; if something needs
+  explaining, KDoc it or name it better.
+- Trailing commas, named arguments in multi-argument converters, `?.toCommon()` for nullable natives.
+- `kotlin.time.Duration` / `Instant` instead of raw millis in the common API — converting to the
+  native representation is the converter's job (see `Animation.android.kt`).
+
+## Build, docs and release touch points
+
+- New module → add to [settings.gradle.kts](settings.gradle.kts), to `dokkaModules` in
+  [build.gradle.kts](build.gradle.kts), and to the module table in [README.md](README.md).
+- User-facing API change → update the matching page under `docs/` and, if it is a new page, the `nav`
+  section of [mkdocs.yml](mkdocs.yml). Docs use Material tabs (`=== "Kotlin"`) and admonitions
+  (`!!! info`, `!!! warning`).
+- iOS targets can be skipped locally with the `skipIosTarget` property; CI publishes from
+  `release/**` branches and deploys docs from `main`.
+
+Details on modules, Gradle wiring and known inconsistencies:
+[references/module-map.md](references/module-map.md).

--- a/.claude/skills/ymk-architecture/references/kotlin-style.md
+++ b/.claude/skills/ymk-architecture/references/kotlin-style.md
@@ -1,0 +1,156 @@
+# Kotlin style in yandex-mapkit-kmp
+
+Every rule here is observable in the existing sources. When a new file disagrees with the codebase,
+the codebase wins — consistency is the point.
+
+## Explicit API
+
+`yandex-mapkit-kmp` and `yandex-mapkit-kmp-compose` build with `-Xexplicit-api=strict`, so the
+compiler rejects a public declaration without an explicit modifier or an inferred return type. Write
+`public` even where it is the default, and always spell the return type:
+
+```kotlin
+public fun Point.toNative(): NativePoint {
+    return NativePoint(latitude.value, longitude.value)
+}
+```
+
+Test sources obey it too — `commonTest` classes and test functions are `public`.
+
+The moko modules do **not** enable it. Their sources use bare `interface MOKOImageLoader` and
+`class AndroidMOKOImageLoader`. Follow whichever module you are in.
+
+Other compiler flags in play: `-Xexpect-actual-classes` (the wrapper relies on `expect class`),
+`-Xconsistent-data-class-copy-visibility` (core), `-Xexport-kdoc` (KDoc reaches the ObjC headers),
+`progressiveMode = true`, and opt-ins for `ExperimentalForeignApi` / `BetaInteropApi` on iOS source
+sets configured centrally in the module's `build.gradle.kts` — do not repeat those opt-ins per file
+unless a file needs one the source set does not grant (`MapKit.ios.kt` opts in at file level).
+
+## Function bodies
+
+Blocks with `return`, not expression bodies:
+
+```kotlin
+public fun NativeMapKit.toCommon(): MapKit {
+    return MapKit(this)
+}
+```
+
+This holds even for one-liners. Property accessors are the exception and use the expression form:
+
+```kotlin
+public actual val version: String
+    get() = nativeMapKit.version
+```
+
+## Naming
+
+- Common types keep the MapKit name: `CameraPosition`, `PlacemarkMapObject`, `VisibleRegion`.
+- Where MapKit's name is too generic for a flat Kotlin package, it gains its domain prefix:
+  `logo.Alignment` → `LogoAlignment`, `logo.Padding` → `LogoPadding`, `logo.HorizontalAlignment` →
+  `LogoHorizontalAlignment`.
+- Enum constants are `UPPER_SNAKE_CASE` (`VECTOR_MAP`, `NO_ROTATION`, `BOTTOM_RIGHT`).
+- Booleans exposed as properties read as predicates: `isVisible`, `isDraggable`, `isNightModeEnabled`,
+  `isValid` — including where the native side spells it `visible` or `draggable`. The `actual`
+  bridges the difference.
+- Nested enums live inside the type they configure when MapKit does the same: `Animation.Type`,
+  `TextStyle.Placement`.
+
+## Value types
+
+`data class` for multi-field values, with defaults where MapKit documents one:
+
+```kotlin
+public data class IconStyle(
+    val anchor: PointF? = null,
+    val rotationType: RotationType? = RotationType.NO_ROTATION,
+    val zIndex: Float? = null,
+    val flat: Boolean? = false,
+    val isVisible: Boolean? = true,
+    val scale: Float? = 1f,
+    val tappableArea: Rect? = null,
+)
+```
+
+`@JvmInline value class` for a single scalar that deserves a type — `Latitude`, `Longitude`, `Color`.
+These wrap the raw value in `value` and add only what callers need (`Comparable` on coordinates,
+`Color.fromArgb` / `toArgb` on colors).
+
+Constants that back defaults are private and live next to the type: a `private companion object` for
+a class member (`TextStyle.DEFAULT_COLOR`), or private file-level `val`/`const` at the bottom of the
+file for Compose defaults (`DefaultStrokeColor`, `DefaultStrokeWidth` in `compose/Circle.kt`).
+
+Secondary constructors are written as top-level functions with the type's name rather than real
+constructors, so the primary constructor keeps the typed parameters:
+
+```kotlin
+public fun Point(latitude: Double, longitude: Double): Point {
+    return Point(Latitude(latitude), Longitude(longitude))
+}
+```
+
+`Geometry` shows the companion-factory variant (`Geometry.fromPoint(...)`) with matching extensions
+(`Point.toGeometry()`), used when MapKit itself exposes a factory.
+
+## Nullability
+
+The common API is honest about optionality: native `NSNumber?` / boxed values become Kotlin nullable
+types, and converters thread them through with `?.`:
+
+```kotlin
+accuracy = accuracy?.doubleValue,
+onFinished = onFinished?.toNative(),
+```
+
+Never `!!` across the boundary. If a native call can genuinely fail to produce a value, the common
+signature returns a nullable (`MapWindow.convertWorldToScreen(...): ScreenPoint?`).
+
+## KDoc
+
+Public wrapper API carries the official MapKit description, and the same KDoc is repeated on the
+`actual` members:
+
+```kotlin
+/**
+ * Notifies MapKit when the application resumes the foreground state.
+ */
+public fun onStart()
+```
+
+Compose API documents behaviour and pitfalls in its own words — see `CameraPositionState`,
+`MapEffect`, `rememberYandexMapController`. Warnings about lifetime and single-ownership belong in
+KDoc, not in comments.
+
+## Comments
+
+There are effectively no explanatory `//` comments in the sources. The few that exist are links to
+upstream documentation in Gradle files. Do not add commentary to Kotlin code — rename, extract, or
+write KDoc instead.
+
+## Imports
+
+- No wildcard imports.
+- Alias imports last, one per native type, named `Native<CommonType>`.
+- Import the converter extensions you use explicitly (`import ru.sulgik.mapkit.geometry.toCommon`) —
+  they are top-level functions in the type's package, not members.
+- When a file needs both the Compose and the MapKit `Color`, alias the foreign one at the bottom
+  (`import androidx.compose.ui.graphics.Color as ComposeColor`) and keep the local one unaliased.
+
+## Tests
+
+`commonTest` uses `kotlin.test`, backtick test names, and a `public companion object` holding
+fixtures:
+
+```kotlin
+public class ColorConvertionTest {
+
+    @Test
+    public fun `mapkit color to compose color should convert correct`() {
+        assertEquals(DefaultMapkitColor.toComposeColor(), DefaultComposeColor)
+    }
+}
+```
+
+Compose UI-state tests use `runComposeUiTest` with `StateRestorationTester` to prove a `Saver`
+survives configuration change — see the (currently commented-out) `MapObjectStatesRestorationTest`
+for the intended shape when adding a new state class.

--- a/.claude/skills/ymk-architecture/references/module-map.md
+++ b/.claude/skills/ymk-architecture/references/module-map.md
@@ -1,0 +1,100 @@
+# Module map, Gradle wiring and known inconsistencies
+
+## Repository layout
+
+```
+yandex-mapkit-kmp/              core wrapper (published)
+yandex-mapkit-kmp-compose/      Compose Multiplatform support (published)
+yandex-mapkit-kmp-moko/         moko-resources ImageProvider (published)
+yandex-mapkit-kmp-moko-compose/ moko-resources + Compose (published)
+sample/composeApp/              sample KMP app
+sample/iosApp/                  Xcode project for the sample
+convention-plugins/             convention.publication.gradle.kts
+docs/                           mkdocs sources (wrapper/, compose/, getting-started/)
+.github/workflows/              docs.yaml (main → gh-pages), publish.yaml (release/** → Central)
+```
+
+## Targets and native dependency
+
+Both published Kotlin modules declare `androidTarget()` plus `iosX64()`, `iosArm64()`,
+`iosSimulatorArm64()`, guarded by:
+
+```kotlin
+val supportIosTarget = project.property("skipIosTarget") != "true"
+```
+
+so `-PskipIosTarget=true` gives an Android-only build on machines without CocoaPods.
+
+The iOS SDK arrives through CocoaPods with a fixed package name, which is why iOS sources import
+`YandexMapKit.YMK*`:
+
+```kotlin
+cocoapods {
+    ios.deploymentTarget = "15.0"
+    framework { baseName = "YandexMapKitKMP" }
+    noPodspec()
+    pod("YandexMapsMobile") {
+        version = libs.versions.yandex.mapkit.get()
+        packageName = "YandexMapKit"
+    }
+}
+```
+
+On Android the native SDK is an `api` dependency (`libs.yandex.mapkit`), so consumers see MapKit
+types. On iOS it is deliberately **not** transitive — consumers link `YandexMapsMobile` themselves,
+as documented in the README.
+
+Compose module dependencies worth remembering: `api(project(":yandex-mapkit-kmp"))`, compose runtime
+/ foundation / ui / components.resources, lifecycle (`api` on `lifecycle-runtime`), `atomicfu` (used
+by `MapWindowOwner`'s reentrant lock) and `kotlinx-collections-immutable` (`api`, because
+`Clustering` takes `ImmutableList`).
+
+## Versions and publication
+
+- `library_version` in `gradle.properties` drives every module's `version`; the publishing block is
+  skipped when it resolves to `"null"`.
+- `gradle/libs.versions.toml` holds Kotlin, AGP, Compose, MapKit (`yandex-mapkit`) and library
+  versions. Bumping MapKit means bumping it there and in the README sentence that names the version.
+- Publication is `com.vanniktech.maven.publish` to Central Portal with signing, `JavadocJar.Empty()`
+  and `androidVariantsToPublish = listOf("release")`. The POM block (name, description, license,
+  developer, scm) is duplicated per module — copy it verbatim for a new module and change only
+  `name` / `description`.
+- KDoc site: root `build.gradle.kts` registers modules in `dokkaModules` and Dokka outputs into
+  `docs/kdoc`, which `mkdocs.yml` links as "API docs".
+
+## Documentation surface
+
+| Change | Update |
+|---|---|
+| New/changed common wrapper API | `docs/wrapper/overview.md` or `docs/wrapper/image-resources.md` |
+| New/changed Compose API | `docs/compose/overview.md`, `compose/mapobjects.md`, `compose/image-resources.md` |
+| New docs page | add it to `nav:` in `mkdocs.yml` |
+| New module | `settings.gradle.kts`, `dokkaModules`, README module table |
+| MapKit version bump | `libs.versions.toml`, README |
+
+Docs style: Material tabs `=== "Kotlin"`, admonitions `!!! info` / `!!! warning`, snippets that
+compile mentally — they are the first thing users copy.
+
+## Known inconsistencies
+
+These exist in the tree today. Do not treat them as patterns, and do not go on a cleanup spree either
+unless asked — just avoid reproducing them.
+
+- **Misnamed platform files**: `geometry/PolylinePosition.andoird.kt`; `location/
+  SubscriptionSettings.android.kt` and `location/UseInBackground.android.kt` live in **iosMain**;
+  `map/MapWindow.kt` in iosMain lacks the `.ios` suffix.
+- **Name drift between common and platform files**: `logo/LogoAlignment.kt` is completed by
+  `logo/Alignment.android.kt` / `Alignment.ios.kt` (same for `Padding`, `HorizontalAlignment`,
+  `VerticalAlignment`).
+- **`LocationManager.ios.kt`** exposes a public constructor while every comparable handle type uses
+  `internal constructor`.
+- **`InputListener.ios.kt`** maps `onMapLongTapWithMap` to `onMapTap` and vice versa — the two
+  callbacks are swapped relative to the Android actual.
+- **`Color.ios.kt`** reads `CIColor.red` etc. without an import of `CIColor` visible in the file.
+- **minSdk drift**: modules set `minSdk = 24`, `libs.versions.toml` says `android-minSdk = "26"`, and
+  the README documents 26.
+- **Test file naming**: `ColorConvertionTest` (missing "s"), and
+  `MapObjectStatesRestorationTest.kt` is entirely commented out.
+
+If a task takes you into one of these files anyway, fixing the local issue is welcome — mention it in
+the commit message rather than in a code comment.

--- a/.claude/skills/ymk-compose-api/SKILL.md
+++ b/.claude/skills/ymk-compose-api/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: ymk-compose-api
+description: >-
+  Recipe for the yandex-mapkit-kmp-compose module — adding or changing map composables, state
+  holders with Savers, MapNode/MapApplier composition nodes, effects, config data classes and
+  ImageProvider helpers, plus the @YandexMapComposable / @YandexMapsComposeExperimentalApi
+  annotation rules and Compose stability config. Use it whenever the work touches Compose map API in
+  this repo — "добавь composable для нового map object", "нужен rememberXxxState", "почему объект не
+  обновляется при рекомпозиции", "добавь параметр в YandexMap/MapConfig", "Clustering",
+  "imageProvider из compose-ресурса". Read it before writing Compose code here.
+---
+
+# Compose API in `yandex-mapkit-kmp-compose`
+
+This module renders the map and lets users describe map contents declaratively. It does that with a
+**second, separate composition** whose nodes are map objects rather than UI nodes — the same trick
+`maps-compose` uses for Google Maps. Understanding that is the key to everything else: inside
+`YandexMap { … }` you are not in the UI composition, so UI composables are unavailable and
+`@YandexMapComposable` is what enforces it at compile time.
+
+The `ymk-architecture` skill covers module-wide naming and style; `ymk-wrapper-api` covers the
+underlying wrapper. This skill assumes both.
+
+## The two public APIs
+
+The module deliberately offers two ways to drive a map, and new features usually need a story for
+both (see [docs/compose/overview.md](docs/compose/overview.md)):
+
+- **States API** — `YandexMap(cameraPositionState, config, content)`, where `content` is a
+  `@[Composable YandexMapComposable] () -> Unit` and map objects are declared as composables.
+  Configuration flows through `MapConfig`; escape hatch is `MapEffect { map -> … }`.
+- **Controller API** — `YandexMap(controller)` with `rememberYandexMapController()`; map access is
+  imperative via `MapControllerEffect(controller) { mapWindow -> … }`. No Compose runtime involved.
+
+Both funnel into `internal expect fun NativeYandexMap(modifier, onRelease, update)`, which wraps the
+platform `MapView` (`AndroidView` on Android, `UIKitView` on iOS) and binds it to the lifecycle.
+
+## How the map composition works
+
+`launchMapComposition` (in `compose/composition/MapComposition.kt`) starts a `Composition` whose
+applier is `MapApplier`, parented to the UI composition so recomposition propagates:
+
+```kotlin
+val composition = Composition(applier = MapApplier(mapWindow), parent = parentComposition)
+composition.setContent {
+    MapUpdater(mapUpdaterState)
+    CompositionLocalProvider(
+        LocalCameraPositionState provides mapUpdaterState.cameraPositionState,
+        LocalMapObjectCollection provides mapWindow.map.mapObjects,
+        LocalMap provides mapWindow.map,
+    ) {
+        content()
+    }
+}
+```
+
+`MapApplier` keeps a flat list of `MapNode`s and calls their lifecycle hooks:
+
+| Hook | When | Typical work |
+|---|---|---|
+| `onAttached()` | node inserted | add listeners to the map object |
+| `onRemoved()` | node leaves the composition | remove listeners, `mapObject.parent.remove(mapObject)` |
+| `onCleared()` | whole composition disposed | drop references so nothing leaks |
+
+Anything you add to the map must be removed in `onRemoved()`, otherwise objects survive their
+composable and stack up on the map.
+
+## Adding a new map object composable
+
+Follow `Circle.kt` / `Placemark.kt` — the full annotated recipe is in
+[references/map-object-recipe.md](references/map-object-recipe.md). The shape is always:
+
+1. `public class XxxState(…)` — `@Immutable`, mutable fields via `mutableStateOf`, plus a
+   `companion object { public val Saver: Saver<XxxState, Any> = listSaver(…) }`.
+2. `public fun rememberXxxState(…, key: String? = null): XxxState` using `rememberSaveable` with that
+   Saver, so the state survives configuration change.
+3. `@[YandexMapComposable Composable] public fun Xxx(state, …, visible, zIndex, onTap)` — the public
+   entry point, which just delegates.
+4. `internal fun XxxImpl(…)` — does the real `MapObjectNode(factory = …, update = …)` call. The split
+   exists so richer variants can reuse it: `TitledPlacemark` calls `PlacemarkImpl` with extra `init`
+   and `update` blocks instead of duplicating the node wiring.
+5. `internal class XxxNode(mapObject, tapListener) : MapObjectNode<XxxMapObject>(mapObject, tapListener)`
+   — only override hooks if the object needs more than tap handling.
+6. Private `DefaultXxx` constants at the bottom of the file.
+
+Inside `MapObjectNode`, `factory` sets the initial native state and `update` re-applies exactly the
+properties that changed:
+
+```kotlin
+update = {
+    update(state.geometry) { this.mapObject.geometry = it }
+    update(strokeColor) { mapObject.strokeColor = strokeColor.toMapkitColor() }
+}
+```
+
+`update(value) { … }` runs the block only when `value` differs from the previous composition — that
+is what keeps MapKit from re-uploading icons on every frame. Reading `state.geometry` inside the
+`update` lambda is what subscribes the node to that snapshot state.
+
+## Rules that keep this module honest
+
+- **Annotate map composables with `@YandexMapComposable`.** It is a `ComposableTargetMarker`, so it
+  makes "UI composable used inside the map composition" a compile error rather than a runtime crash.
+  The combined form `@[YandexMapComposable Composable]` is the house spelling.
+- **New or unstable API gets `@YandexMapsComposeExperimentalApi`** (`RequiresOptIn`, WARNING level).
+  Everything composable-content-as-icon, clustering-by-content and user-location related is currently
+  behind it — follow suit when behaviour differs across platforms or the design is still moving.
+- **Public state classes are `@Immutable` and hold `mutableStateOf` fields**; internal updater states
+  are `@Stable`. Setters that only the library may call are `internal set`
+  (`CameraPositionState.isMoving`, `PlacemarkState.isDragging`).
+- **One state instance drives one map.** `MapWindowOwner` enforces it with a reentrant lock and
+  fails loudly (`"YandexMapController may only be associated with one MapView at a time"`). Any new
+  state that owns a `MapWindow` should reuse `MapWindowOwner` rather than invent its own guard.
+- **`CompositionLocal`s are `internal`** and error when unset:
+  `compositionLocalOf<MapObjectCollection> { error("No MapObjectCollection provided") }`. Expose a
+  public read-only accessor when users need it, as `currentCameraPositionState` does.
+- **Colors cross via `compose.utils`**: `ComposeColor.toMapkitColor()` inbound,
+  `Color.toComposeColor()` outbound. Public Compose API takes `androidx.compose.ui.graphics.Color`,
+  never the MapKit `Color`.
+- **Collections in public API are `ImmutableList`** (`Clustering(groups: ImmutableList<ClusterGroup>)`)
+  so Compose can treat them as stable; provide a `List`-taking convenience overload if it helps
+  callers, as `ClusterGroup(points: List<Point>, …)` does.
+- **Wrapper types used as composable parameters must be listed in
+  [compose_compiler_stability_config.conf](yandex-mapkit-kmp-compose/compose_compiler_stability_config.conf)**
+  — the compiler cannot see stability across module boundaries. Adding a new wrapper type to a
+  composable signature without adding it there silently makes every recomposition skip-less.
+
+## Key-overload family
+
+`MapEffect`, `MapControllerEffect`, `imageProvider` and `clusterImageProvider` each ship the same
+overload ladder: `key1`, `key1+key2`, `key1+key2+key3`, `vararg keys`. It mirrors Compose's own
+`LaunchedEffect`/`remember` API so users get familiar restart semantics. When you add a new effect or
+provider, provide the whole ladder rather than a single `vararg` — `vararg` allocates and breaks the
+common no-key case.
+
+## Checklist
+
+- [ ] Map-composition composables carry `@YandexMapComposable`; experimental ones also carry
+      `@YandexMapsComposeExperimentalApi`.
+- [ ] State class has a `Saver` and a `rememberXxxState(key: String? = null)` factory.
+- [ ] Node removes everything it added in `onRemoved()` and drops references in `onCleared()`.
+- [ ] `update(...)` blocks cover every mutable parameter, and nothing else.
+- [ ] New wrapper types in composable signatures added to the stability config.
+- [ ] `expect`/`actual` Compose functions repeat annotations on both sides.
+- [ ] Docs updated: `docs/compose/overview.md`, `docs/compose/mapobjects.md` or
+      `docs/compose/image-resources.md`.
+- [ ] `./gradlew :yandex-mapkit-kmp-compose:compileDebugKotlinAndroid
+      :yandex-mapkit-kmp-compose:compileKotlinIosSimulatorArm64` and, if states changed,
+      `:yandex-mapkit-kmp-compose:allTests`.

--- a/.claude/skills/ymk-compose-api/references/map-object-recipe.md
+++ b/.claude/skills/ymk-compose-api/references/map-object-recipe.md
@@ -1,0 +1,201 @@
+# Adding a map object composable, end to end
+
+Worked example following `compose/Circle.kt` and `compose/Placemark.kt`. Everything lives in one
+file named after the composable, under `commonMain/.../compose/`.
+
+## 1. State holder + Saver
+
+```kotlin
+@Composable
+public fun rememberCircleState(geometry: Circle, key: String? = null): CircleState {
+    return rememberSaveable(
+        key = key,
+        saver = CircleState.Saver,
+    ) { CircleState(geometry) }
+}
+
+@Immutable
+public class CircleState(geometry: Circle) {
+
+    public var geometry: Circle by mutableStateOf(geometry)
+
+    public companion object {
+        public val Saver: Saver<CircleState, Any> = listSaver(
+            save = {
+                listOf(
+                    it.geometry.center.latitude.value,
+                    it.geometry.center.longitude.value,
+                    it.geometry.radius,
+                )
+            },
+            restore = {
+                CircleState(
+                    geometry = Circle(
+                        center = Point(it[0].toDouble(), it[1].toDouble()),
+                        radius = it[2].toFloat(),
+                    )
+                )
+            }
+        )
+    }
+}
+```
+
+Why it looks like this:
+
+- `listSaver` flattens to primitives because `rememberSaveable` must survive process death, where
+  only bundle-friendly values are guaranteed.
+- The `key: String?` parameter lets callers disambiguate several states of the same type in one
+  composable — `rememberSaveable` keys off call-site position otherwise.
+- Fields the library writes but users only read are `internal set`
+  (`PlacemarkState.isDragging`, updated from the drag listener).
+- The KDoc on `rememberXxxState` states the tradeoff plainly ("Other use cases may be better served
+  syncing … with a data model") — keep that honesty when adding a new one.
+
+## 2. Public composable
+
+```kotlin
+@[YandexMapComposable Composable]
+public fun Circle(
+    state: CircleState,
+    color: Color = DefaultFillColor,
+    strokeColor: Color = DefaultStrokeColor,
+    strokeWidth: Float = DefaultStrokeWidth,
+    geodesic: Boolean = DefaultGeodesic,
+    visible: Boolean = true,
+    zIndex: Float = 0.0f,
+    onTap: ((Point) -> Boolean)? = null,
+) {
+    CircleImpl(
+        state = state,
+        color = color,
+        strokeColor = strokeColor,
+        strokeWidth = strokeWidth,
+        geodesic = geodesic,
+        visible = visible,
+        zIndex = zIndex,
+        onTap = onTap,
+    )
+}
+```
+
+Parameter order across the module: `state` first, then object-specific appearance, then the common
+tail `visible`, `draggable`, `zIndex`, `opacity`, `onTap`. Colors are Compose colors. `onTap` returns
+`Boolean` because MapKit uses the return value to mark the event consumed.
+
+## 3. Impl + node wiring
+
+```kotlin
+@[YandexMapComposable Composable]
+internal fun CircleImpl(
+    state: CircleState,
+    color: Color = DefaultFillColor,
+    …
+) {
+    val collection = LocalMapObjectCollection.current
+    MapObjectNode(
+        visible = visible,
+        zIndex = zIndex,
+        onTap = onTap,
+        factory = {
+            val mapObject = collection.addCircle(state.geometry)
+            mapObject.strokeColor = strokeColor.toMapkitColor()
+            mapObject.fillColor = color.toMapkitColor()
+            CircleNode(mapObject = mapObject, tapListener = onTap)
+        },
+        update = {
+            update(state.geometry) { this.mapObject.geometry = it }
+            update(strokeColor) { mapObject.strokeColor = strokeColor.toMapkitColor() }
+            update(color) { mapObject.fillColor = color.toMapkitColor() }
+        }
+    )
+}
+
+internal class CircleNode(
+    mapObject: CircleMapObject,
+    tapListener: ((Point) -> Boolean)?
+) : MapObjectNode<CircleMapObject>(mapObject, tapListener)
+
+private val DefaultStrokeColor = Color(0xFF66FF00)
+private const val DefaultStrokeWidth = 5f
+private val DefaultFillColor = Color(0x9966FF00)
+private const val DefaultGeodesic = false
+```
+
+`MapObjectNode` (in `compose/MapObject.kt`) already handles `visible`, `zIndex` and the tap listener,
+so nodes only add what is specific to their object. It also fails fast when used outside the map
+composition:
+
+```kotlin
+val mapApplier = currentComposer.applier as? MapApplier
+    ?: error("Creating ${T::class} from not YandexMapComposable is not supported")
+```
+
+The base `MapObjectNode` removes itself from its parent collection on `onRemoved()` and drops the tap
+listener — a node that adds anything else (a drag listener, child placemarks) must undo it there too:
+
+```kotlin
+internal class PlacemarkNode(…) : MapObjectNode<PlacemarkMapObject>(mapObject, tapListener) {
+
+    private var nativeDragListener: MapObjectDragListener? = MapObjectDragListener(
+        onMapObjectDrag = { _, point -> state.geometry = point },
+        onMapObjectDragStart = { _ -> state.isDragging = true },
+        onMapObjectDragEnd = { _ -> state.isDragging = false }
+    )
+
+    override fun onAttached() {
+        super.onAttached()
+        mapObject.setDragListener(nativeDragListener)
+    }
+
+    override fun onRemoved() {
+        mapObject.setDragListener(null)
+        super.onRemoved()
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        nativeDragListener = null
+    }
+}
+```
+
+Note the direction: `onAttached`/`onRemoved` call `super` in the order that keeps the object alive
+while its listeners are being managed, and `onCleared` nulls references so the native listener does
+not outlive the composition.
+
+## 4. Variants that reuse Impl
+
+`PlacemarkImpl` is `inline` and takes `init: PlacemarkNode.() -> Unit` and
+`update: @DisallowComposableCalls Updater<PlacemarkNode>.() -> Unit` hooks, which is how
+`TitledPlacemark` adds text without duplicating node wiring:
+
+```kotlin
+PlacemarkImpl(
+    state = state,
+    …,
+    init = { mapObject.setText(title, titleStyle) },
+    update = {
+        update(title) { this.mapObject.setText(title, titleStyle) }
+        update(titleStyle) { this.mapObject.setTextStyle(titleStyle) }
+    }
+)
+```
+
+`@DisallowComposableCalls` on the update lambda is required — the `Updater` block runs outside
+composition, so a composable call there would be a runtime crash.
+
+Stateful nodes that need more than property updates (like `ClusterNode`) keep custom `var`s with
+setters that push into MapKit, and re-cluster when the group list or config changes. Look at
+`Clustering.kt` before writing anything with a collection of child objects.
+
+## 5. Wire-up beyond the file
+
+- Add any new wrapper type appearing in a composable signature to
+  `compose_compiler_stability_config.conf`.
+- Document the composable in `docs/compose/mapobjects.md` with a `=== "Kotlin"` tab, and add it to
+  the "List of supported nodes" list in that page.
+- If it needs an icon, check whether `imageProvider(resource)` covers it or an experimental
+  `imageProvider(size, content)` variant is warranted.
+- Consider a state-restoration test mirroring the shape kept in
+  `commonTest/.../MapObjectStatesRestorationTest.kt`.

--- a/.claude/skills/ymk-conventions-review/SKILL.md
+++ b/.claude/skills/ymk-conventions-review/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: ymk-conventions-review
+description: >-
+  Convention audit for yandex-mapkit-kmp changes — checks a diff, a file or generated code against
+  the repo's rules: expect/actual symmetry, toNative()/toCommon() placement and naming, Native*
+  aliases, platform file suffixes, explicit API, KDoc and no-comment policy, listener identity,
+  Compose node cleanup and stability config. Use it when reviewing or self-checking work in this
+  repo — "проверь, что соответствует конвенциям", "отревьюй мой диф", "я дописал обёртку, всё ли по
+  правилам", "почему листенер не отписывается", before opening a PR, and right after generating a
+  batch of wrapper or Compose code.
+---
+
+# Convention review for yandex-mapkit-kmp
+
+Run this over a change before it lands. The goal is not style policing for its own sake — every item
+below has a failure mode attached, and most of them fail silently at runtime rather than at compile
+time, which is exactly why a checklist earns its keep here.
+
+Work through the sections that apply to the change. For each finding, state the file, the rule and
+the concrete consequence. Fix mechanical issues directly; flag anything that changes public API
+shape for the author to decide.
+
+## Scope the review first
+
+```bash
+git diff --stat main...HEAD
+git diff main...HEAD -- '*.kt'
+```
+
+If the change touches `commonMain`, both platform source sets must be in the diff too — a new
+`expect` member with only one `actual` does not compile, but a new *optional* member or a converter
+added on one platform only will happily ship half-done.
+
+## 1. Boundary discipline
+
+| Check | Command / how | Why it matters |
+|---|---|---|
+| No converters in common | `grep -rn "toNative\|toCommon" --include='*.kt' */src/commonMain` should only match imports of common-side helpers, never declarations | `commonMain` must not know a native type exists |
+| No native imports in common | `grep -rn "^import com\.yandex\|^import YandexMapKit" --include='*.kt' */src/commonMain` → expect zero hits | same |
+| Alias for the file's native type | native counterpart imported `as Native<CommonType>`, alias imports last | keeps Android/iOS actuals diffable line by line |
+| Converter names | only `toNative` / `toCommon` — no `asNative`, `convert`, `fromNative` | the two-word vocabulary is the wrapper's readability contract |
+
+Domain converters with other verbs (`toGeometry`, `toImageProvider`, `toMapkitColor`, `toArgb`) are
+fine — they do not cross the native boundary.
+
+## 2. File and package placement
+
+```bash
+find */src/androidMain */src/iosMain -name '*.kt' ! -name '*.android.kt' ! -name '*.ios.kt'
+find . -path '*/iosMain/*' -name '*.android.kt' -o -path '*/androidMain/*' -name '*.ios.kt'
+```
+
+Expected survivors of the first command are only platform-only types with no common counterpart
+(`AndroidImageProvider.kt`, `UIImageImageProvider.kt`) plus the known-bad `map/MapWindow.kt` and
+`PolylinePosition.andoird.kt`. Anything new showing up there is a mistake.
+
+The second command should return only the two known-misplaced `location/*.android.kt` files in
+`iosMain`. A new hit means a file was created in the wrong source set — it will compile (the suffix
+is not semantic) and then confuse everyone forever.
+
+Also verify the package mirrors MapKit (`ru.sulgik.mapkit.<mapkit package>`) and the file is named
+after its single public type.
+
+## 3. expect / actual symmetry
+
+- Every `expect` member has an `actual` on both platforms, in the same order, with the same KDoc.
+- Default parameter values only on the `expect` side.
+- `expect abstract class X()` has `actual constructor()` in both actuals.
+- Handle types: `internal constructor`, member `toNative()` returning the platform type, top-level
+  `NativeX.toCommon()`.
+- A new `MapObject` subtype is registered in the `when` inside `MapObject.toCommon()` (and
+  `BaseMapObjectCollection.toCommon()` for collections) on **both** platforms. Miss this and objects
+  coming back from listeners or `traverse` arrive as the base wrapper — no compile error, just a
+  failed cast or missing API at runtime.
+
+Quick way to compare the two actuals of a type:
+
+```bash
+diff <(grep -o 'actual [a-z]* [a-zA-Z]*' */src/androidMain/**/Foo.android.kt) \
+     <(grep -o 'actual [a-z]* [a-zA-Z]*' */src/iosMain/**/Foo.ios.kt)
+```
+
+## 4. Listener identity
+
+The single highest-value check in this repo:
+
+- `toNative()` on a listener returns a **stored field**, not a freshly built adapter.
+- The iOS adapter extends `NSObject` alongside the `*Protocol`.
+- Native callback names are wired to the matching common method — read them side by side. Precedent
+  for why: `InputListener.ios.kt` currently maps `onMapTapWithMap` to `onMapLongTap` and vice versa.
+- Common code offers an `inline` factory taking lambdas, so users are not forced to subclass.
+
+Consequence of getting the first one wrong: `removeXListener` compares by identity, so removal
+silently no-ops and MapKit's weak references can collect the listener mid-session.
+
+## 5. Enum and nullability handling
+
+- Both directions implemented, `when` exhaustive.
+- iOS `toCommon()` ends with
+  `else -> throw IllegalArgumentException("Unknown NativeX ($this)")` — never a fallback value.
+- Nullable native values map to nullable common values with `?.`; no `!!`, no invented defaults.
+- Round-trip sanity for value types: `x.toNative().toCommon() == x`.
+- Named arguments used when a converter fills more than ~3 fields, so field reordering cannot
+  silently swap values of the same type (`Float` zoom/azimuth/tilt is the classic trap here).
+
+## 6. Style
+
+- Explicit `public` and explicit return types in `yandex-mapkit-kmp` and
+  `yandex-mapkit-kmp-compose` (not in the moko modules, which do not enable explicit API).
+- Block bodies with `return`, expression bodies only for property getters.
+- KDoc on new public API, repeated on the actuals.
+- **No `//` comments.** `grep -rn '^\s*//' --include='*.kt' <changed files>` should be empty;
+  existing hits are commented-out code in `LayerIds.ios.kt` and `MapObjectStatesRestorationTest.kt`.
+- Trailing commas, no wildcard imports, private default constants next to their type.
+
+## 7. Compose module extras
+
+- Map-composition composables carry `@YandexMapComposable`; unstable API also carries
+  `@YandexMapsComposeExperimentalApi`, and `expect`/`actual` pairs repeat both.
+- State classes are `@Immutable` with a `Saver` and a `rememberXxxState(key: String? = null)`.
+- Every node undoes in `onRemoved()` what it did in `onAttached()`/`factory`, and clears references in
+  `onCleared()`. A missed removal leaves objects on the map after the composable leaves.
+- `update(value) { … }` exists for each mutable parameter and nothing more — a missing `update` means
+  the parameter silently stops working after the first composition.
+- New wrapper types used in composable signatures are added to
+  `compose_compiler_stability_config.conf`, otherwise recomposition never skips.
+- Public Compose API takes `androidx.compose.ui.graphics.Color` and converts with
+  `toMapkitColor()`; collections are `ImmutableList`.
+
+## 8. Surrounding artefacts
+
+- Public API change → matching page under `docs/` updated (and `mkdocs.yml` `nav` for a new page).
+- New module → `settings.gradle.kts`, `dokkaModules`, README table.
+- MapKit version bump → `libs.versions.toml` and the README sentence naming the version.
+
+## 9. Compile
+
+Nothing counts as reviewed until it builds on both platforms:
+
+```bash
+./gradlew :yandex-mapkit-kmp:compileDebugKotlinAndroid :yandex-mapkit-kmp:compileKotlinIosSimulatorArm64
+```
+
+```bash
+./gradlew :yandex-mapkit-kmp-compose:compileDebugKotlinAndroid :yandex-mapkit-kmp-compose:compileKotlinIosSimulatorArm64
+```
+
+Without CocoaPods available, `-PskipIosTarget=true` builds Android only — say so explicitly in the
+review instead of implying iOS was verified.
+
+## Reporting
+
+Group findings by severity and be concrete about the consequence:
+
+```
+Blocking
+- map/FooMapObject.android.kt:41 — toCommon() dispatch in MapObject.toCommon() not extended;
+  foo objects from traverse() arrive as MapObject and the cast in Clustering fails at runtime.
+
+Should fix
+- map/FooListener.ios.kt:12 — toNative() builds a new adapter per call; removeFooListener will
+  never remove it.
+
+Nit
+- map/Foo.kt:7 — expression body; the codebase uses block bodies with return.
+```
+
+Known pre-existing deviations (misnamed files, `LocationManager.ios.kt`'s public constructor, the
+swapped `InputListener` callbacks) are not the author's fault — mention them only if the change
+touches those files.

--- a/.claude/skills/ymk-wrapper-api/SKILL.md
+++ b/.claude/skills/ymk-wrapper-api/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: ymk-wrapper-api
+description: >-
+  Recipe for adding or changing wrapped MapKit API in the yandex-mapkit-kmp core module — choosing
+  between a value type, a handle type (expect class over a live native object) and a listener,
+  writing the expect/actual pair, the toNative()/toCommon() converters for Android and iOS, and the
+  enum, nullable and NSNumber edge cases. Use this whenever the task is to expose, wrap, extend or
+  fix a MapKit type, property, method, listener or callback in common code — including asks like
+  "оберни X из MapKit", "добавь метод в Map", "нужен листенер на Y", "поддержи новый тип geometry",
+  "почему toCommon падает на iOS". Reach for it before writing any expect/actual or converter code.
+---
+
+# Wrapping MapKit API in `yandex-mapkit-kmp`
+
+The wrapper's contract with its users: *common code sees a Kotlin-shaped MapKit; native types never
+leak into `commonMain`.* Every decision below serves that contract, so when a case is not covered
+here, pick whatever keeps native types out of common code and keeps the two converter names.
+
+If you have not read the `ymk-architecture` skill yet, read it first — package layout, file naming
+and the `Native*` alias rule are assumed here.
+
+## Step 1 — pick the pattern
+
+Ask what the thing *is* on the native side:
+
+| Native shape | Pattern | Examples |
+|---|---|---|
+| Plain data, copied by value | **Value type** — `data class` / `value class` in common, converters per platform | `Point`, `CameraPosition`, `IconStyle`, `Location`, `Animation` |
+| Live object with identity and mutable state | **Handle type** — `expect class` wrapping the native instance | `Map`, `MapWindow`, `PlacemarkMapObject`, `LocationManager`, `Logo` |
+| Interface/protocol the SDK calls back into | **Listener** — `expect abstract class` + inline factory | `InputListener`, `CameraListener`, `ClusterListener`, `Callback` |
+| Closed set of constants | **Enum** — `enum class` in common, `when` converters both ways | `MapType`, `RotationType`, `CameraUpdateReason` |
+
+Mixed cases follow the dominant shape: `Cluster` holds native state, so it is a handle type even
+though it lives in `geometry`.
+
+Full annotated templates for each pattern, including the traps:
+[references/type-patterns.md](references/type-patterns.md).
+
+## Step 2 — write the common declaration
+
+Value type — everything in `commonMain`, no mention of anything native:
+
+```kotlin
+package ru.sulgik.mapkit.map
+
+public data class CameraPosition(
+    val target: Point,
+    val zoom: Float,
+    val azimuth: Float,
+    val tilt: Float,
+)
+```
+
+Handle type — `expect class` listing only what the wrapper exposes, with KDoc from the MapKit docs.
+Note what is *absent*: no constructor, no `toNative()`. Instances only ever come from `toCommon()`,
+and the native type differs per platform, so it cannot appear in the `expect`:
+
+```kotlin
+public expect class MapWindow {
+
+    /**
+     * Gets the map interface.
+     */
+    public val map: Map
+
+    public var focusPoint: ScreenPoint?
+
+    public fun convertWorldToScreen(worldPoint: Point): ScreenPoint?
+
+    public val isValid: Boolean
+}
+```
+
+Default argument values belong on the `expect` side only — `actual` members repeat the parameter
+without the default (`setText(text: String, style: TextStyle = TextStyle())` in common,
+`setText(text: String, style: TextStyle)` in each actual).
+
+## Step 3 — write the actuals
+
+Android and iOS actuals are deliberately near-identical, differing only in the native call spelling
+(`setIcon(...)` vs `setIconWithImage(...)`, `isVisible` vs `visible`). Keep member order the same in
+both files so a diff between them shows only real platform differences.
+
+```kotlin
+public actual class MapWindow internal constructor(private val nativeMapWindow: NativeMapWindow) {
+
+    public fun toNative(): NativeMapWindow {
+        return nativeMapWindow
+    }
+
+    public actual val map: Map
+        get() = nativeMapWindow.map.toCommon()
+}
+
+public fun NativeMapWindow.toCommon(): MapWindow {
+    return MapWindow(this)
+}
+```
+
+`internal constructor` is what stops users from fabricating a wrapper around a native object they
+should not own; `toNative()` is public so platform code can drop back down to the SDK.
+
+For a type hierarchy, the base `toCommon()` dispatches so callers get the most specific wrapper:
+
+```kotlin
+public fun NativeMapObject.toCommon(): MapObject {
+    return when (this) {
+        is NativeBaseMapObjectCollection -> toCommon()
+        is NativeCircleMapObject -> toCommon()
+        is NativePlacemarkMapObject -> toCommon()
+        else -> MapObject(this)
+    }
+}
+```
+
+When you add a new `MapObject` subclass, add its branch here **and** in
+`BaseMapObjectCollection.toCommon()` if it is a collection — otherwise map objects arriving from
+listeners silently degrade to the base wrapper.
+
+## Step 4 — converters
+
+Value types get a symmetric pair of top-level extensions in each platform file:
+
+```kotlin
+public fun CameraPosition.toNative(): NativeCameraPosition {
+    return NativeCameraPosition.cameraPositionWithTarget(target.toNative(), zoom, azimuth, tilt)
+}
+
+public fun NativeCameraPosition.toCommon(): CameraPosition {
+    return CameraPosition(target.toCommon(), zoom, azimuth, tilt)
+}
+```
+
+Rules that keep converters trustworthy:
+
+- Convert every nested field through its own converter (`target.toNative()`), never by hand.
+- Nullable native values map to nullable common values with `?.` — no `!!`, no silent defaults.
+- Use named arguments when the constructor takes more than ~3 fields, so a reordering of the data
+  class does not silently mis-map values.
+- Round-trip must hold: `x.toNative().toCommon() == x` for value types. Anything that cannot
+  round-trip (like `Geometry`, whose native form is a union) throws explicitly rather than guessing:
+  `else -> throw IllegalStateException("Conversion common $this to native is not available")`.
+
+Enums use exhaustive `when` in both directions. On iOS the Objective-C enum is not exhaustive from
+Kotlin's point of view, so `toCommon()` needs the failing branch — copy the message shape used
+elsewhere:
+
+```kotlin
+else -> throw IllegalArgumentException("Unknown NativeMapType ($this)")
+```
+
+## Step 5 — check yourself
+
+- [ ] Common file has zero native imports; `toNative`/`toCommon` appear only under `androidMain` /
+      `iosMain`.
+- [ ] The file's native counterpart imported as `Native<CommonType>`, alias imports at the end of the
+      import block.
+- [ ] Android and iOS actuals expose the same members in the same order, both with KDoc.
+- [ ] New handle type: `internal constructor`, member `toNative()`, top-level `toCommon()`, and a
+      branch in any parent `toCommon()` dispatcher.
+- [ ] New listener: single `nativeListener` field (see below), plus the inline factory in common.
+- [ ] Explicit `public`, explicit return types, block bodies with `return`, no `//` comments.
+- [ ] Docs under `docs/` and the README touched if the public surface changed.
+- [ ] `./gradlew :yandex-mapkit-kmp:compileKotlinIosSimulatorArm64
+      :yandex-mapkit-kmp:compileDebugKotlinAndroid` (or `-PskipIosTarget=true` when no CocoaPods).
+
+## The listener trap worth memorising
+
+`toNative()` on a listener must return **the same instance every time**. The SDK's `removeXListener`
+compares by identity, and MapKit holds listeners weakly — building a fresh adapter per call means
+removal silently fails and the listener can be collected mid-flight. So the adapter is a field:
+
+```kotlin
+public actual abstract class ClusterListener actual constructor() {
+
+    private val nativeListener = NativeClusterListener { onClusterAdded(it.toCommon()) }
+
+    public fun toNative(): NativeClusterListener {
+        return nativeListener
+    }
+
+    public actual abstract fun onClusterAdded(cluster: Cluster)
+}
+```
+
+On iOS the adapter additionally has to be an `NSObject` to satisfy the protocol:
+`object : NativeClusterListener, NSObject() { … }`.
+
+Common code also gets a lambda-friendly factory so users are not forced to subclass:
+
+```kotlin
+public inline fun ClusterListener(crossinline onClusterAdded: (cluster: Cluster) -> Unit): ClusterListener {
+    return object : ClusterListener() {
+        override fun onClusterAdded(cluster: Cluster) {
+            onClusterAdded.invoke(cluster)
+        }
+    }
+}
+```
+
+iOS-specific mechanics — `NSNumber` boxing, `CValue`/`useContents`, `NSDate` ↔ `Instant`, protocol
+naming (`YMKFooProtocol`), factory constructors (`fooWithBar(...)`):
+[references/ios-interop.md](references/ios-interop.md).

--- a/.claude/skills/ymk-wrapper-api/references/ios-interop.md
+++ b/.claude/skills/ymk-wrapper-api/references/ios-interop.md
@@ -1,0 +1,108 @@
+# iOS interop notes
+
+The Objective-C SDK reaches Kotlin through the `YandexMapKit` CocoaPods package name, so every iOS
+source imports `YandexMapKit.YMK*` under a `Native*` alias. What follows are the recurring frictions
+and how this repo resolves them.
+
+## Naming translation
+
+| Objective-C | Kotlin/Native | In this repo |
+|---|---|---|
+| `YMKPoint` | class | `import YandexMapKit.YMKPoint as NativePoint` |
+| `YMKMapInputListener` protocol | `YMKMapInputListenerProtocol` | alias `NativeInputListener` |
+| `+[YMKPoint pointWithLatitude:longitude:]` | `NativePoint.pointWithLatitude(lat, lon)` | used instead of a constructor |
+| `-[YMKMap setIconWithImage:style:]` | `setIconWithImage(image, style)` | the `With<FirstArg>` suffix is normal |
+| `YMKMapTypeVectorMap` | enum entry `NativeMapType.YMKMapTypeVectorMap` | mapped in `when` |
+| `isValid` | `isValid()` — a function, not a property | `public actual val isValid: Boolean get() = nativeX.isValid()` |
+
+Protocols must be implemented by an `NSObject` subclass:
+
+```kotlin
+private val nativeListener = object : NativeClusterListener, NSObject() { … }
+```
+
+## Boxed numbers
+
+Optional scalars arrive as `NSNumber?`. Unwrap with the typed accessor, box with the internal helpers
+in `NSNumber.ios.kt`:
+
+```kotlin
+accuracy = accuracy?.doubleValue          // native → common
+accuracy = accuracy?.toNSNumber()          // common → native
+```
+
+`toNSNumber()` exists for `Int`, `Long`, `Boolean`, `Float`, `Double` and is `internal` — add an
+overload there rather than calling `NSNumber.numberWith*` at the call site.
+
+## CoreGraphics structs
+
+`CGPoint` / `CGRect` come back as `CValue<…>`, which cannot be read directly:
+
+```kotlin
+public fun PointF.toNative(): CValue<CGPoint> {
+    return CGPointMake(x.toDouble(), y.toDouble())
+}
+
+public fun CGPoint.toCommon(): PointF {
+    return PointF(x.toFloat(), y.toFloat())
+}
+```
+
+When the SDK hands over an `NSValue` box, open it with `useContents`:
+
+```kotlin
+internal fun NSValue.toPointF(): PointF {
+    return CGPointValue.useContents { toCommon() }
+}
+```
+
+`useContents` runs its block inside the struct's scope — do not let the receiver escape it; convert
+to a common type inside the block, as above.
+
+## Time
+
+The common API speaks `kotlin.time`. iOS speaks `NSDate` and seconds:
+
+```kotlin
+absoluteTimestamp = absoluteTimestamp.toNSDate()        // common → native
+absoluteTimestamp = absoluteTimestamp.toKotlinInstant() // native → common
+```
+
+Android's `Animation` takes seconds as `Float`, so its converter does the arithmetic explicitly
+(`duration.inWholeMilliseconds / 1000f`). Keep such unit conversion inside the converter — the common
+type stays a `Duration`.
+
+## Colors
+
+`Color` is ARGB-packed in common code; iOS needs a `UIColor` with normalized components, so
+`Color.ios.kt` does the shifting in both directions. Android's side is a plain `Int`, which is why
+there is no `Color.android.kt`.
+
+## Opt-ins
+
+`ExperimentalForeignApi` and `BetaInteropApi` are opted in for every iOS source set in the module's
+`build.gradle.kts`:
+
+```kotlin
+sourceSets.all {
+    languageSettings.apply {
+        progressiveMode = true
+        if (name.lowercase().contains("ios")) {
+            optIn("kotlinx.cinterop.ExperimentalForeignApi")
+            optIn("kotlinx.cinterop.BetaInteropApi")
+        }
+    }
+}
+```
+
+Only add a file-level `@file:OptIn(...)` when a file needs something beyond that (as `MapKit.ios.kt`
+does) — repeating the source-set opt-ins per file is noise.
+
+## Building without a Mac setup
+
+`-PskipIosTarget=true` drops the iOS targets and the CocoaPods block, so Android-only work can build
+and test. Anything touching `iosMain` still needs a real compile before it is called done:
+
+```bash
+./gradlew :yandex-mapkit-kmp:compileKotlinIosSimulatorArm64
+```

--- a/.claude/skills/ymk-wrapper-api/references/type-patterns.md
+++ b/.claude/skills/ymk-wrapper-api/references/type-patterns.md
@@ -1,0 +1,237 @@
+# The three wrapper patterns, end to end
+
+Each section shows the complete set of files for one pattern, taken from working code in the repo.
+
+## 1. Value type
+
+Immutable data that crosses the boundary by copy. The common declaration knows nothing about
+platforms.
+
+**`commonMain/.../geometry/Point.kt`**
+
+```kotlin
+package ru.sulgik.mapkit.geometry
+
+public data class Point(val latitude: Latitude, val longitude: Longitude)
+
+public fun Point(latitude: Double, longitude: Double): Point {
+    return Point(Latitude(latitude), Longitude(longitude))
+}
+```
+
+**`androidMain/.../geometry/Point.android.kt`**
+
+```kotlin
+package ru.sulgik.mapkit.geometry
+
+import com.yandex.mapkit.geometry.Point as NativePoint
+
+public fun Point.toNative(): NativePoint {
+    return NativePoint(latitude.value, longitude.value)
+}
+
+public fun NativePoint.toCommon(): Point {
+    return Point(Latitude(latitude), Longitude(longitude))
+}
+```
+
+**`iosMain/.../geometry/Point.ios.kt`** — same shape, native factory instead of a constructor:
+
+```kotlin
+import YandexMapKit.YMKPoint as NativePoint
+
+public fun Point.toNative(): NativePoint {
+    return NativePoint.pointWithLatitude(latitude.value, longitude.value)
+}
+```
+
+Scalar wrappers use `@JvmInline value class` and expose the raw value as `value`:
+
+```kotlin
+@JvmInline
+public value class Latitude(public val value: Double) : Comparable<Latitude> {
+    override fun compareTo(other: Latitude): Int {
+        return value.compareTo(other.value)
+    }
+}
+```
+
+`Color` is the variant where the raw value stays `internal` and access goes through
+`Color.fromArgb(...)` / `toArgb()`, because the ARGB layout is an implementation detail the
+platform converters translate (`UIColor` on iOS, plain `Int` on Android).
+
+### Union-shaped values
+
+`Geometry` models MapKit's tagged union as a data class of nullable fields with a private
+constructor and named factories, plus `toGeometry()` extensions on each member type. Its `toNative()`
+picks the first non-null branch and throws when none matches — a union with no arm set is a
+programming error, not a default.
+
+## 2. Handle type
+
+Wraps a live native object. The class is `expect` so the wrapper type is one type in common code,
+and each `actual` stores the native instance.
+
+**`commonMain/.../map/PlacemarkMapObject.kt`**
+
+```kotlin
+public expect class PlacemarkMapObject : MapObject {
+
+    public var geometry: Point
+
+    public var direction: Float
+
+    public fun setText(
+        text: String,
+        style: TextStyle = TextStyle(),
+    )
+
+    public fun setIcon(
+        image: ImageProvider,
+        style: IconStyle = IconStyle(),
+        onFinished: Callback? = null,
+    )
+}
+```
+
+**`androidMain/.../map/PlacemarkMapObject.android.kt`**
+
+```kotlin
+public actual class PlacemarkMapObject internal constructor(private val nativePlacemarkMapObject: NativePlacemarkMapObject) :
+    MapObject(nativePlacemarkMapObject) {
+
+    override fun toNative(): NativePlacemarkMapObject {
+        return nativePlacemarkMapObject
+    }
+
+    public actual var geometry: Point
+        get() = nativePlacemarkMapObject.geometry.toCommon()
+        set(value) {
+            nativePlacemarkMapObject.geometry = value.toNative()
+        }
+
+    public actual fun setText(text: String, style: TextStyle) {
+        nativePlacemarkMapObject.setText(text, style.toNative())
+    }
+}
+
+public fun NativePlacemarkMapObject.toCommon(): PlacemarkMapObject {
+    return PlacemarkMapObject(this)
+}
+```
+
+Points to keep:
+
+- The subclass passes its native object up to the base wrapper's constructor and **overrides
+  `toNative()` with the narrower return type**, so callers of a `PlacemarkMapObject` get
+  `NativePlacemarkMapObject` back, not `NativeMapObject`.
+- `MapObject.toNative()` is declared `public open fun` in each actual — it is not part of the
+  `expect` class, because its return type is platform-specific.
+- Properties bridge naming differences at the actual level: Android `isVisible`, iOS `visible`, both
+  exposed as `isVisible`.
+- Optional native parameters get an `if`/`else` on Android when the SDK offers overloads instead of
+  nullable arguments (`setIcon` with and without `onFinished`), while iOS passes `onFinished?.toNative()`.
+
+### Types that must be created, not only wrapped
+
+`MapObjectCollection.addPlacemark()` and friends return wrappers built from the native return value —
+creation happens through the parent handle, never through a public wrapper constructor. If new API
+needs a factory, put it on the owning handle type, mirroring MapKit.
+
+## 3. Listener / callback
+
+**`commonMain/.../map/InputListener.kt`**
+
+```kotlin
+public expect abstract class InputListener() {
+    public abstract fun onMapTap(map: Map, point: Point)
+    public abstract fun onMapLongTap(map: Map, point: Point)
+}
+
+public inline fun InputListener(
+    crossinline onMapTap: (map: Map, point: Point) -> Unit,
+    crossinline onMapLongTap: (map: Map, point: Point) -> Unit,
+): InputListener {
+    return object : InputListener() {
+        override fun onMapTap(map: Map, point: Point) {
+            onMapTap.invoke(map, point)
+        }
+
+        override fun onMapLongTap(map: Map, point: Point) {
+            onMapLongTap.invoke(map, point)
+        }
+    }
+}
+```
+
+The `expect abstract class X()` needs the explicit empty constructor, and every `actual` repeats it
+as `actual constructor()`.
+
+**`androidMain`** — the adapter is a stored field, and native payloads are converted on the way in:
+
+```kotlin
+public actual abstract class InputListener actual constructor() {
+    private val nativeListener = object : NativeInputListener {
+        override fun onMapTap(p0: NativeMap, p1: NativePoint) {
+            onMapTap(p0.toCommon(), p1.toCommon())
+        }
+
+        override fun onMapLongTap(p0: NativeMap, p1: NativePoint) {
+            onMapLongTap(p0.toCommon(), p1.toCommon())
+        }
+    }
+
+    public fun toNative(): NativeInputListener {
+        return nativeListener
+    }
+
+    public actual abstract fun onMapTap(map: Map, point: Point)
+
+    public actual abstract fun onMapLongTap(map: Map, point: Point)
+}
+```
+
+**`iosMain`** — same, but the adapter must extend `NSObject` to implement a `*Protocol`, and the
+native method names carry their `WithX` suffixes:
+
+```kotlin
+private val nativeListener = object : NativeInputListener, NSObject() {
+    override fun onMapTapWithMap(map: NativeMap, point: NativePoint) {
+        onMapTap(map.toCommon(), point.toCommon())
+    }
+}
+```
+
+Take the mapping between native and common callback names seriously — `InputListener.ios.kt`
+currently has `onMapTapWithMap` wired to `onMapLongTap` and vice versa, which is exactly the kind of
+bug this shape invites. Read the native signature twice.
+
+Single-method callbacks can collapse further when the native side is a functional type:
+`Callback.ios.kt` returns a method reference (`return ::onTaskFinished`), and
+`Callback.android.kt` uses a SAM conversion (`NativeCallback { onTaskFinished() }`).
+
+Listeners with a return value keep it: `MapObjectTapListener.onMapObjectTap(...): Boolean` returns
+straight through to the SDK, since MapKit uses it to mark the event consumed.
+
+## 4. Enum
+
+```kotlin
+public enum class MapType {
+    /**
+     * Do not use any of the predefined maps.
+     */
+    NONE,
+    /**
+     * Raster map.
+     */
+    MAP,
+}
+```
+
+Android converters map one-to-one and stay exhaustive in both directions. iOS `toCommon()` must add
+`else -> throw IllegalArgumentException("Unknown NativeMapType ($this)")` because Kotlin sees the
+Objective-C enum as open. Never map an unknown native constant onto an arbitrary common value —
+throwing surfaces an SDK upgrade immediately instead of producing a wrong map.
+
+Nested enums (`TextStyle.Placement`, `Animation.Type`) get their own converter pair alongside the
+parent's, in the same file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,121 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this project is
+
+A Kotlin Multiplatform wrapper over the official Yandex MapKit SDK (Android `com.yandex.mapkit`,
+iOS `YandexMapKit`/`YMK*` via CocoaPods), published as `ru.sulgik.mapkit:*`. It is not a Yandex
+project.
+
+The contract that drives every design decision: **common code sees a Kotlin-shaped MapKit, and native
+types never leak into `commonMain`.** When a rule below looks arbitrary, check it against that
+sentence — it usually explains it.
+
+## Commands
+
+```bash
+./gradlew build                        # everything; iOS targets need CocoaPods installed
+./gradlew build -PskipIosTarget=true   # Android-only, for machines without CocoaPods
+```
+
+Per-target compile checks (fastest feedback when changing `expect`/`actual` pairs — always run both):
+
+```bash
+./gradlew :yandex-mapkit-kmp:compileDebugKotlinAndroid :yandex-mapkit-kmp:compileKotlinIosSimulatorArm64
+```
+
+```bash
+./gradlew :yandex-mapkit-kmp-compose:compileDebugKotlinAndroid :yandex-mapkit-kmp-compose:compileKotlinIosSimulatorArm64
+```
+
+Tests live in `yandex-mapkit-kmp-compose/src/commonTest`:
+
+```bash
+./gradlew :yandex-mapkit-kmp-compose:allTests
+```
+
+```bash
+./gradlew :yandex-mapkit-kmp-compose:testDebugUnitTest --tests "ru.sulgik.mapkit.ColorConvertionTest"
+```
+
+KDoc site and docs:
+
+```bash
+./gradlew :dokkaGenerate    # renders into docs/kdoc, linked from mkdocs as "API docs"
+```
+
+```bash
+mkdocs serve                # needs pip install mkdocs-material
+```
+
+Sample app — requires `MAPKIT_API_KEY=<key>` in `local.properties`, otherwise the buildKonfig step
+fails with an explicit message. Android: `./gradlew :sample:composeApp:installDebug`. iOS: open
+`sample/iosApp/iosApp.xcworkspace` in Xcode.
+
+There is no linter task; correctness is enforced by `-Xexplicit-api=strict` and the compiler.
+
+Publishing runs in CI from `release/**` branches (the branch suffix becomes `library_version`);
+docs deploy from `main`. Do not publish locally.
+
+## Architecture in one page
+
+Four published modules plus a sample:
+
+- `yandex-mapkit-kmp` — the wrapper itself, package `ru.sulgik.mapkit.*` mirroring MapKit's own
+  packages (`geometry`, `map`, `location`, `logo`, `indoor`, `layers`, `user_location`, `mapview`).
+  Users migrate by swapping the import prefix, so package and type names must keep matching MapKit.
+- `yandex-mapkit-kmp-compose` — Compose Multiplatform rendering. Runs a **second composition** whose
+  applier is `MapApplier` and whose nodes are map objects, so `@YandexMapComposable` content cannot
+  contain UI composables.
+- `yandex-mapkit-kmp-moko` / `-moko-compose` — moko-resources images as `ImageProvider`. These two
+  do **not** enable explicit API; match whichever module you are editing.
+
+Every type falls into one of three shapes:
+
+1. **Value type** — `data class` / `@JvmInline value class` in `commonMain`, converters per platform.
+2. **Handle type** — `expect class` in common; `actual class X internal constructor(private val nativeX: NativeX)`
+   with a member `toNative()` and a top-level `NativeX.toCommon()` in each platform source set.
+3. **Listener** — `expect abstract class X()` plus an `inline` lambda factory in common; each actual
+   holds one stored `nativeListener` field returned by `toNative()`.
+
+Boundary crossings are spelled with exactly two names, `toNative()` and `toCommon()`, and exist only
+in `androidMain` / `iosMain` — never in `commonMain`.
+
+## Conventions that are easy to get wrong
+
+- Platform files are named `Type.android.kt` / `Type.ios.kt`; only platform-exclusive types
+  (`AndroidImageProvider.kt`, `UIImageImageProvider.kt`) drop the suffix.
+- The file's native counterpart is imported as `Native<CommonType>`, with alias imports last.
+- **No `//` comments in Kotlin code.** Public API gets KDoc (copied from MapKit's docs and repeated
+  on the actuals); everything else should be readable without prose.
+- Explicit `public` and explicit return types; block bodies with `return`, expression bodies only for
+  property getters.
+- A listener's `toNative()` must return the same stored instance every time — MapKit removes
+  listeners by identity and holds them weakly.
+- Adding a `MapObject` subtype means adding its branch to the `when` in `MapObject.toCommon()` on
+  both platforms, otherwise objects silently arrive as the base wrapper.
+- iOS enum `toCommon()` needs `else -> throw IllegalArgumentException("Unknown NativeX ($this)")`;
+  never fall back to a default value.
+- Compose: nodes must undo in `onRemoved()` whatever they added, every mutable parameter needs an
+  `update(...)` block, and new wrapper types used in composable signatures must be listed in
+  `yandex-mapkit-kmp-compose/compose_compiler_stability_config.conf`.
+
+Public API changes also touch `docs/` (and `mkdocs.yml` `nav` for a new page) and the README module
+table.
+
+## Skills
+
+Detailed, task-specific guidance lives in `.claude/skills/` — read the relevant one before writing
+code rather than inferring patterns from a single file:
+
+| Skill | Use when |
+|---|---|
+| `ymk-architecture` | Orienting in the repo: module map, packages, file naming, Kotlin style |
+| `ymk-wrapper-api` | Wrapping or changing MapKit API in the core module, incl. iOS interop details |
+| `ymk-compose-api` | Adding Compose map objects, states, effects, image providers |
+| `ymk-conventions-review` | Auditing a diff before opening a PR |
+
+The skills also record known deviations already present in the tree (misnamed platform files,
+swapped callbacks in `InputListener.ios.kt`, `minSdk` drift between modules and the README) — treat
+those as bugs to avoid copying, not as precedent.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ above official Yandex MapKit SDK**
 # Available libraries
 
 The following libraries are available. It
-uses [Yandex MapKit SDK](https://yandex.ru/dev/mapkit/doc/ru/) version *4.23.0-lite*
+uses [Yandex MapKit SDK](https://yandex.ru/dev/mapkit/doc/ru/) version *4.24.0-lite*
 
 | Module	                                        | Gradle Dependency                                                                                                                             | Description                                                                                                                                              |
 |------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
Adds a `CLAUDE.md` and four skills under `.claude/skills/` that document how this repository is built, so both contributors and Claude Code follow the same conventions.

## CLAUDE.md

Short, always-loaded entry point: build and per-target compile commands, how to run tests (including a single one), docs and sample setup, a one-page architecture summary (the three wrapper type shapes, the `toNative()` / `toCommon()` boundary rule, the separate Compose map composition) and the conventions that are easy to get wrong. Details are delegated to the skills rather than duplicated.

## Skills

| Skill | Scope |
|---|---|
| `ymk-architecture` | Module map, package layout mirroring MapKit, source-set and file naming, Kotlin house style (explicit API, block bodies, KDoc policy, no inline comments) |
| `ymk-wrapper-api` | Adding wrapped MapKit API to the core module: value / handle / listener patterns, `expect`–`actual` pairs, `toNative()` / `toCommon()` converters, enum and nullable edge cases, iOS interop (`NSNumber`, `CValue`, protocols) |
| `ymk-compose-api` | Compose module: the two public APIs, `MapApplier` / `MapNode` composition, recipe for a new map object composable (state + `Saver` + `rememberXxxState` + node), annotation and stability-config rules |
| `ymk-conventions-review` | Convention audit checklist with runnable grep commands, used before opening a PR |

Every rule is derived from existing code and explained through its failure mode rather than stated as a bare requirement — for example why a listener's `toNative()` must return a stored field (`removeXListener` compares by identity, so a fresh adapter makes removal silently no-op).

## Known deviations recorded

The skills also list existing inconsistencies as "do not copy", among them:

- `PolylinePosition.andoird.kt`; `SubscriptionSettings.android.kt` and `UseInBackground.android.kt` located in `iosMain`; `map/MapWindow.kt` in `iosMain` without the `.ios` suffix
- `LocationManager.ios.kt` exposing a public constructor where other handle types use `internal constructor`
- `InputListener.ios.kt` wiring `onMapTapWithMap` to `onMapLongTap` and vice versa
- `minSdk` set to 24 in the modules while `libs.versions.toml` and the README say 26

## Note on the diff

The branch was cut from `main`, which is one commit ahead of `develop`, so this PR also carries that commit's README change (MapKit version `4.23.0-lite` → `4.24.0-lite`). Documentation only — no production code is touched.