### PR TITLE
Link .worktreeinclude entries into git worktrees

### DIFF
--- a/.claude/scripts/worktree-include.sh
+++ b/.claude/scripts/worktree-include.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+payload=""
+if [ ! -t 0 ]; then
+  payload=$(cat || true)
+fi
+
+if [ -n "$payload" ]; then
+  hook_cwd=$(printf '%s' "$payload" | jq -r '.new_cwd // .cwd // empty' 2>/dev/null || true)
+  if [ -n "$hook_cwd" ] && [ -d "$hook_cwd" ]; then
+    cd "$hook_cwd"
+  fi
+fi
+
+git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
+[ -f "$git_dir/gitdir" ] || exit 0
+
+common_dir=$(cd "$(git rev-parse --git-common-dir)" && pwd)
+main_root=$(dirname "$common_dir")
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+include_file="$repo_root/.worktreeinclude"
+[ -f "$include_file" ] || include_file="$main_root/.worktreeinclude"
+[ -f "$include_file" ] || exit 0
+
+linked=""
+relinked=""
+while IFS= read -r raw || [ -n "$raw" ]; do
+  entry="${raw%%#*}"
+  entry="$(printf '%s' "$entry" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's:/*$::')"
+  [ -z "$entry" ] && continue
+  case "$entry" in /*|*..*) continue ;; esac
+
+  target="$main_root/$entry"
+  [ -e "$target" ] || continue
+
+  if [ -L "$entry" ]; then
+    [ "$(readlink "$entry")" = "$target" ] && continue
+    rm -f -- "$entry"
+    ln -s "$target" "$entry"
+    relinked="$relinked $entry"
+    continue
+  fi
+
+  if [ -e "$entry" ]; then
+    rm -rf -- "$entry"
+    ln -s "$target" "$entry"
+    relinked="$relinked $entry"
+    continue
+  fi
+
+  mkdir -p "$(dirname "$entry")"
+  ln -s "$target" "$entry"
+  linked="$linked $entry"
+done < "$include_file"
+
+[ -n "$linked" ] && echo "worktree-include: linked$linked from $main_root"
+[ -n "$relinked" ] && echo "worktree-include: relinked$relinked from $main_root"
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/scripts/worktree-include.sh\"",
+            "timeout": 15,
+            "statusMessage": "Linking .worktreeinclude entries"
+          }
+        ]
+      }
+    ],
+    "CwdChanged": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/scripts/worktree-include.sh\"",
+            "timeout": 15,
+            "statusMessage": "Linking .worktreeinclude entries"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Pods/
 *.podspec
 .kotlin
 docs/kdoc
+.claude/worktrees/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,1 @@
+local.properties


### PR DESCRIPTION
## Problem

`git worktree add` materializes tracked content only, so gitignored developer files never reach a worktree. Here that means `local.properties` — and with it `MAPKIT_API_KEY` — is absent. `getMapkitApiKey()` in `sample/composeApp/build.gradle.kts` throws inside its own `try`, so the missing key is swallowed by the `catch` and the sample builds with an empty key: the app runs, the map never loads.

## Change

- `.worktreeinclude` — newline-separated list of paths to share with worktrees (currently just `local.properties`)
- `.claude/scripts/worktree-include.sh` — symlinks each listed path from the main checkout into the worktree
- `.claude/settings.json` — runs it on `SessionStart` and `CwdChanged`
- `.gitignore` — ignore `.claude/worktrees/`

The script is a no-op outside a linked worktree, idempotent across repeat runs, and reads the list from the worktree first, falling back to the main checkout — so an untracked `.worktreeinclude` works too. Entries that are absolute or contain `..` are skipped.

## Verified

Ran against all four local worktrees: `local.properties` links to the main checkout, repeat runs stay quiet, and running it in the main checkout does nothing. Confirmed end to end by removing the link in a worktree and starting a session there — the hook restored it.