### PR TITLE
Fix the Objective-C export crash and link frameworks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,9 @@ jobs:
       - name: Compile both targets and run simulator tests
         run: ./gradlew libraryCompileIosArm64 libraryIosTests
 
+      - name: Link the Objective-C frameworks
+        run: ./gradlew libraryLinkIosFramework
+
       - name: Upload test reports
         if: failure()
         uses: actions/upload-artifact@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Uses Yandex MapKit 4.42.0-lite. Set this version in your `Podfile` or `podspec`.
 
 - The cluster listener is retained by `ClusterNode` instead of being a factory local, so clustering
   keeps working after the factory is collected.
+- Linking an Objective-C framework no longer crashes the Kotlin 2.4 compiler with a
+  `NullPointerException` in `ObjCExportCodeGenerator`. The bounds of `WeakRef<T>.toNative()` are
+  spelled without an explicit `T : Any`, which is what the compiler trips over; the signature is
+  unchanged for callers. CI now links the frameworks so this cannot regress unnoticed.
+- `yandex-mapkit-kmp-moko-compose` declares `compose.foundation`, which pinned it to the 1.7.0
+  artifact pulled in by moko-resources and failed to build a Kotlin/Native cache.
 
 ## [0.4.1] - 2025-10-17
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,13 @@ Per-target compile checks (fastest feedback when changing `expect`/`actual` pair
 ./gradlew :yandex-mapkit-kmp-compose:compileAndroidMain :yandex-mapkit-kmp-compose:compileKotlinIosSimulatorArm64
 ```
 
+Compiling for iOS only produces a klib; the Objective-C export runs when a framework is linked, and
+it has its own failure modes. Anything that changes an exported signature should also be checked with:
+
+```bash
+./gradlew libraryLinkIosFramework
+```
+
 Tests live in `yandex-mapkit-kmp-compose/src/commonTest`:
 
 ```bash

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,9 +3,12 @@ import org.jetbrains.dokka.ExternalDocumentationLink
 import org.jetbrains.dokka.ExternalDocumentationLinkImpl
 import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 import org.jetbrains.dokka.gradle.GradleExternalDocumentationLinkBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.abi.BinariesSource
 import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import java.net.URL
 import java.util.Properties
 
@@ -101,6 +104,13 @@ registerLibraryTask(
 )
 
 registerLibraryTask(
+    name = "libraryLinkIosFramework",
+    taskName = "linkPodDebugFrameworkIosArm64",
+    taskGroup = "build",
+    taskDescription = "Links the Objective-C frameworks of the published modules for the iOS device target.",
+)
+
+registerLibraryTask(
     name = "libraryApiCheck",
     taskName = "checkKotlinAbi",
     taskGroup = "verification",
@@ -127,6 +137,25 @@ subprojects {
         }
 
         configureAbiValidation()
+        configureYandexMapsMobileLinking()
+    }
+}
+
+private val yandexMapsMobileFrameworks = listOf(
+    "CoreLocation",
+    "SystemConfiguration",
+    "NetworkExtension",
+)
+
+fun Project.configureYandexMapsMobileLinking() {
+    afterEvaluate {
+        val kotlin = extensions.findByType<KotlinMultiplatformExtension>() ?: return@afterEvaluate
+
+        kotlin.targets.withType<KotlinNativeTarget>().configureEach {
+            binaries.withType<Framework>().configureEach {
+                yandexMapsMobileFrameworks.forEach { linkerOpts("-framework", it) }
+            }
+        }
     }
 }
 

--- a/yandex-mapkit-kmp-moko-compose/build.gradle.kts
+++ b/yandex-mapkit-kmp-moko-compose/build.gradle.kts
@@ -66,6 +66,7 @@ kotlin {
             api(libs.moko.resources.compose)
             implementation(compose.runtime)
             implementation(compose.ui)
+            implementation(compose.foundation)
         }
 
         commonTest.dependencies {

--- a/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/NativeConvertible.android.kt
+++ b/yandex-mapkit-kmp/src/androidMain/kotlin/ru/sulgik/mapkit/NativeConvertible.android.kt
@@ -17,7 +17,6 @@ public interface NativeConvertible<T : Any> {
  * If the referent has already been collected, the returned reference is empty as well, so the
  * subscription it is passed to never fires.
  */
-public fun <T, N : Any> WeakRef<T>.toNative(): WeakReference<N>
-        where T : Any, T : NativeConvertible<N> {
+public fun <T : NativeConvertible<N>, N : Any> WeakRef<T>.toNative(): WeakReference<N> {
     return WeakReference<N>(get()?.toNative())
 }

--- a/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/NativeConvertible.ios.kt
+++ b/yandex-mapkit-kmp/src/iosMain/kotlin/ru/sulgik/mapkit/NativeConvertible.ios.kt
@@ -15,7 +15,6 @@ public interface NativeConvertible<T : Any> {
  * The SDK stores such objects as `__weak` pointers, so the caller stays responsible for keeping the
  * referent alive.
  */
-public fun <T, N : Any> WeakRef<T>.toNative(): N?
-        where T : Any, T : NativeConvertible<N> {
+public fun <T : NativeConvertible<N>, N : Any> WeakRef<T>.toNative(): N? {
     return get()?.toNative()
 }


### PR DESCRIPTION
Linking any Objective-C framework of the library crashes the Kotlin 2.4 compiler, so the library
cannot be exported to Swift at all. It reproduces on a clean checkout of `3e405c6`.

```
e: Compilation failed: null
 * Compiler version: 2.4.10
 * Output kind: FRAMEWORK
e: java.lang.NullPointerException
	at ...KlibModuleOriginKt.getKlibModuleOrigin(KlibModuleOrigin.kt:32)
	at ...LlvmModuleSpecificationBase.containsDeclaration(LlvmModuleSpecificationImpl.kt:43)
	at ...ObjCExportCodeGeneratorKt.createFinalMethodAdapter(ObjCExportCodeGenerator.kt:1355)
```

## The trigger

A compiler bug, not a MapKit one. Reduced to five lines, one file, no dependencies:

```kotlin
interface Conv

fun <T> convert(value: T): Any? where T : Any, T : Conv {
    return value
}
```

A public **top-level** function whose type parameter has **multiple upper bounds, one of them an
explicit `Any` and another an interface**, makes the Objective-C exporter fail while building the
adapter for the synthetic file class. Narrowed by bisecting the exported surface with
`@HiddenFromObjC`, then confirmed both ways: hiding only that declaration removes the crash, and a
standalone project reproduces it.

| | |
|---|---|
| `where T : Any, T : Conv` | crashes |
| `where T : Conv, T : Any` | crashes |
| `<T : Conv>`, single bound | fine |
| `where T : Other, T : Conv`, no `Any` | fine |
| `where T : Any, T : Base`, class bound | fine |
| same signature as a class member | fine |
| `internal`, not exported | fine |

It is a **regression**: 2.2.20 and 2.3.20 build it, 2.4.0 and 2.4.10 crash. `-Xexport-kdoc` is not
involved — it fails without that flag too. Only Apple targets are affected: the klib
(`compileKotlinIosArm64`) and Android compile fine, the failure is purely in Objective-C export.

## The fix

`WeakRef<T>.toNative()` is the only declaration of that shape in the repository, so its bounds are
spelled without the redundant explicit `T : Any` — `NativeConvertible<N>` is already a non-nullable
bound. Callers see the same signature and the klib ABI dump is unchanged.

```diff
-public fun <T, N : Any> WeakRef<T>.toNative(): N?
-        where T : Any, T : NativeConvertible<N> {
+public fun <T : NativeConvertible<N>, N : Any> WeakRef<T>.toNative(): N? {
```

An upstream YouTrack issue is being filed; no existing one matches.

## Why CI missed it

`test-ios` ran `libraryCompileIosArm64`, which stops at the klib and never links a framework.
`libraryLinkIosFramework` links the frameworks of all four published modules and now runs in that
job. Verified it fails on the old signature and passes on the new one.

Two pre-existing problems had to be fixed for that check to pass:

- The `YandexMapsMobile` podspec declares system frameworks that the CocoaPods Gradle plugin does
  not pass to the linker, so linking failed on undefined `CoreLocation`, `SystemConfiguration` and
  `NetworkExtension` symbols. They are added centrally in the root build, next to
  `configureAbiValidation()`.
- `yandex-mapkit-kmp-moko-compose` never declared `compose.foundation`, so it stayed on the 1.7.0
  artifact pulled in by moko-resources while `runtime` and `ui` were already aligned to 1.11.1. That
  1.7.0 klib fails to build a Kotlin/Native cache under 2.4.

## Checks

`spotlessCheck`, `libraryAssemble`, `libraryTests`, `libraryIosTests`, `libraryCompileIosArm64`,
`libraryApiCheck` and `libraryLinkIosFramework` all pass locally.