### PR TITLE
Render composable icons through a software canvas

### DIFF
--- a/yandex-mapkit-kmp-compose/src/commonMain/kotlin/ru/sulgik/mapkit/compose/ComposeMapObjectRenderer.kt
+++ b/yandex-mapkit-kmp-compose/src/commonMain/kotlin/ru/sulgik/mapkit/compose/ComposeMapObjectRenderer.kt
@@ -16,11 +16,20 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.MeasurePolicy
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.toSize
 import kotlinx.coroutines.channels.Channel
 import ru.sulgik.mapkit.map.ImageProvider
 
@@ -117,6 +126,7 @@ internal fun ComposeMapObjectSlots(renderer: ComposeMapObjectRenderer) {
 @Composable
 private fun ComposeMapObjectSlotContent(slot: ComposeMapObjectSlot) {
     val density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
     val layer = rememberGraphicsLayer()
     val records = remember(layer) { Channel<Unit>(Channel.CONFLATED) }
     Layout(
@@ -132,13 +142,25 @@ private fun ComposeMapObjectSlotContent(slot: ComposeMapObjectSlot) {
         },
         measurePolicy = DetachedContentMeasurePolicy,
     )
-    LaunchedEffect(slot, layer, density) {
+    LaunchedEffect(slot, layer, density, layoutDirection) {
         for (record in records) {
             val size = layer.size
             if (size.width <= 0 || size.height <= 0) continue
-            slot.updateImage(layer.toImageBitmap().toImageProvider(density))
+            val image = layer.drawToImageBitmap(density, layoutDirection)
+            slot.updateImage(image.toImageProvider(density))
         }
     }
+}
+
+private fun GraphicsLayer.drawToImageBitmap(
+    density: Density,
+    layoutDirection: LayoutDirection,
+): ImageBitmap {
+    val image = ImageBitmap(size.width, size.height)
+    CanvasDrawScope().draw(density, layoutDirection, Canvas(image), size.toSize()) {
+        drawLayer(this@drawToImageBitmap)
+    }
+    return image
 }
 
 private val DetachedContentMeasurePolicy = MeasurePolicy { measurables, _ ->


### PR DESCRIPTION
Fixes the release run that failed on `ComposeMapObjectRendererTest`:
https://github.com/SuLG-ik/yandex-mapkit-kmp/actions/runs/30701052817

```
java.lang.NullPointerException: Attempt to invoke virtual method
'android.graphics.Bitmap$Config android.graphics.Bitmap.getConfig()' on a null object reference
  at ComposeImageResource_androidKt.asArgb8888(ComposeImageResource.android.kt:19)
  at ComposeMapObjectRendererKt$ComposeMapObjectSlotContent$2$1.invokeSuspend(ComposeMapObjectRenderer.kt:139)
```

## Why

`GraphicsLayer.toImageBitmap()` snapshots the layer through `LayerSnapshotV28`, which is
`Bitmap.createBitmap(Picture)` with `requiresHardwareAcceleration() = true`. On a device without
hardware rendering — the `aosp_atd` emulator CI runs the instrumented tests on — it returns `null`.
Kotlin sees a platform type, so nothing checks it, and the NPE surfaces on the first `Bitmap`
access in `asArgb8888()`.

`#47` introduced this rendering path, and instrumented tests only run on pushes to `main` and in
the release workflow, so it went green on its own PR.

## What changed

`ComposeMapObjectSlotContent` now draws the layer into a software `ImageBitmap` itself.
`AndroidGraphicsLayer.draw()` checks `canvas.nativeCanvas.isHardwareAccelerated` and replays the
recorded block through `CanvasDrawScope` when it is not, so the content renders on any device and
the hardware snapshot is no longer involved. The code is common, so iOS takes the same path.

Two side effects:

- the bitmap is ARGB_8888 already, so `asArgb8888()` stops copying it on every icon frame;
- `layoutDirection` joins the `LaunchedEffect` keys, so icons re-render when it changes.

## Verified

- `compileAndroidMain` + `compileKotlinIosSimulatorArm64`
- `:yandex-mapkit-kmp-compose:connectedAndroidDeviceTest` — 9/9 on API 34 and API 29, both with `-gpu swiftshader_indirect`
- `spotlessCheck`, `:yandex-mapkit-kmp-compose:iosSimulatorArm64Test`

**The failure itself does not reproduce locally** — the old code passes on both emulators above, so
these runs only show the absence of a regression. The `aosp_atd` image CI uses is not available in
the local SDK. The fix rests on reading `LayerSnapshot.android.kt` and `AndroidGraphicsLayer.android.kt`,
and the real check is a `dry_run` of the release workflow once this lands.